### PR TITLE
Use a list to store D6 roll states

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -42,7 +42,7 @@ DIGITS = "0123456789"
 LETTERS = "abcdefghijklmnopqrstuvwxyz"
 BITS = "01"
 
-D6_STATES = "123456"
+D6_STATES = [str(i + 1) for i in range(6)]
 D20_STATES = [str(i + 1) for i in range(20)]
 
 D6_MIN_ROLLS = 50


### PR DESCRIPTION
Fixes a bug where you can enter invalid numbers like "45" as a valid roll because `"45" in D6_STATES == True` 🤦