### PR TITLE
Bug fix - Amigo wouldn't update with SDcard

### DIFF
--- a/src/krux/firmware.py
+++ b/src/krux/firmware.py
@@ -197,6 +197,7 @@ def upgrade():
         t("New firmware detected.\n\nSHA256:\n%s\n\n\n\nInstall?")
         % binascii.hexlify(firmware_hash).decode()
     )
+    inp.buttons_active = True
     if inp.wait_for_button() != BUTTON_ENTER:
         return False
 


### PR DESCRIPTION
Buttons were disabled at boot as it starts in "touch mode" so `ENTER` press will return `None` at first time