### PR TITLE
Fix settings regression

### DIFF
--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -43,9 +43,9 @@ class SettingsNamespace:
     def setting_list(self):
         """Returns the list of child Setting objects"""
         return [
-            setting
-            for setting in self.__class__.__dict__.values()
-            if isinstance(setting, Setting)
+            getattr(self.__class__, setting)
+            for setting in dir(self.__class__)
+            if isinstance(getattr(self.__class__, setting), Setting)
         ]
 
 
@@ -86,6 +86,8 @@ class Setting:
         self.default_value = default_value
 
     def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
         return store.get(obj.namespace, self.attr, self.default_value)
 
     def __set__(self, obj, value):

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -940,6 +940,9 @@ def test_settings(mocker, m5stickv):
                 BUTTON_ENTER,
                 # Paper Width
                 BUTTON_PAGE,
+                BUTTON_PAGE,
+                BUTTON_PAGE,
+                BUTTON_PAGE,
                 BUTTON_ENTER,
                 # Change width
                 # Remove digit
@@ -958,8 +961,9 @@ def test_settings(mocker, m5stickv):
                 BUTTON_PAGE,
                 BUTTON_ENTER,
                 # Back to Thermal
-                BUTTON_PAGE_PREV,
-                BUTTON_PAGE_PREV,
+                BUTTON_PAGE,
+                BUTTON_PAGE,
+                BUTTON_PAGE,
                 BUTTON_ENTER,
                 # Back to Printer
                 BUTTON_PAGE,


### PR DESCRIPTION
Micropython behaves differently than Python 3 in quirky ways. In this case, you can't call `__dict__` on a class/type object, only on an instance object. Thus, the tests passed and the simulator worked fine, but an error occurred when testing on a real device.

This PR fixes that regression to instead call the global `dir` function on the class/type object which micropython does support.