### PR TITLE
Thermal print scale and speed settings

### DIFF
--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -308,23 +308,24 @@ class Display:
         time.sleep_ms(duration)
         self.clear()
 
-    def draw_qr_code(self, offset_y, qr_code, bright=False):
-        """Draws a QR code on the screen"""
-        # Add a 1px white border around the code before displaying
+    def add_qr_frame(self, qr_code):
+        """Add a 1px white border around the code before displaying"""
         qr_code = qr_code.strip()
         lines = qr_code.split("\n")
         size = len(lines)
-        new_lines = ["0" * (size + 2)]
+        size += 2
+        new_lines = ["0" * size]
         for line in lines:
             new_lines.append("0" + line + "0")
-        new_lines.append("0" * (size + 2))
-        qr_code = "\n".join(new_lines)
-        if bright:
-            lcd.draw_qr_code(offset_y, qr_code, self.width(), lcd.BLACK, lcd.WHITE)
-        else:
-            lcd.draw_qr_code(
-                offset_y, qr_code, self.width(), QR_DARK_COLOR, QR_LIGHT_COLOR
-            )
+        new_lines.append("0" * size)
+        return size, "\n".join(new_lines)
+
+    def draw_qr_code(
+        self, offset_y, qr_code, dark_color=QR_DARK_COLOR, light_color=QR_LIGHT_COLOR
+    ):
+        """Draws a QR code on the screen"""
+        _, qr_code = self.add_qr_frame(qr_code)
+        lcd.draw_qr_code(offset_y, qr_code, self.width(), dark_color, light_color)
 
     def set_backlight(self, level):
         """Sets the backlight of the display to the given power level, from 0 to 8"""

--- a/src/krux/krux_settings.py
+++ b/src/krux/krux_settings.py
@@ -130,9 +130,10 @@ class AdafruitPrinterSettings(SettingsNamespace):
     paper_width = NumberSetting(int, "paper_width", 384, [100, 1000])
     tx_pin = NumberSetting(int, "tx_pin", DEFAULT_TX_PIN, [0, 10000])
     rx_pin = NumberSetting(int, "rx_pin", DEFAULT_RX_PIN, [0, 10000])
-    heat_dots = NumberSetting(int, "heat_dots", 11, [0, 255])
     heat_time = NumberSetting(int, "heat_time", 120, [3, 255])
     heat_interval = NumberSetting(int, "heat_interval", 40, [0, 255])
+    line_delay = NumberSetting(int, "line_delay", 20, [0, 255])
+    scale = NumberSetting(int, "scale", 75, [25, 100])
 
     def label(self, attr):
         """Returns a label for UI when given a setting name or namespace"""
@@ -141,9 +142,10 @@ class AdafruitPrinterSettings(SettingsNamespace):
             "paper_width": t("Paper Width"),
             "tx_pin": t("TX Pin"),
             "rx_pin": t("RX Pin"),
-            "heat_dots": t("Heat Dots"),
             "heat_time": t("Heat Time"),
             "heat_interval": t("Heat Interval"),
+            "line_delay": t("Line Delay"),
+            "scale": t("Scale"),
         }[attr]
 
 

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -235,6 +235,29 @@ class Page:
             )
         return (code, qr_format)
 
+    def highlight_qr_region(self, code, region=(0, 0, 0, 0)):
+        """Draws in white a highlighted region of the QR code"""
+        reg_x, reg_y, reg_width, reg_height = region
+        size, code = self.ctx.display.add_qr_frame(code)
+        # starting size is the amount of blocks per line
+        max_width = self.ctx.display.width()
+        # scale is how many pixels per block
+        scale = max_width // size
+        qr_width = size * scale
+        offset = (max_width - qr_width) // 2
+        for y in range(reg_height):  # vertical blocks loop
+            for x in range(reg_width):  # horizontal blocks loop
+                xy_index = (reg_y + y + 1) * (size + 1)
+                xy_index += reg_x + x + 1
+                if code[xy_index] == "0":
+                    self.ctx.display.fill_rectangle(
+                        offset + (reg_x + x + 1) * scale,
+                        offset + (reg_y + y + 1) * scale,
+                        scale,
+                        scale,
+                        lcd.WHITE,
+                    )
+
     def display_qr_codes(self, data, qr_format, title=None):
         """Displays a QR code or an animated series of QR codes to the user, encoding them
         in the specified format

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -235,24 +235,35 @@ class Page:
             )
         return (code, qr_format)
 
-    def highlight_qr_region(self, code, region=(0, 0, 0, 0)):
+    def highlight_qr_region(self, code, region=(0, 0, 0, 0), zoom=False):
         """Draws in white a highlighted region of the QR code"""
         reg_x, reg_y, reg_width, reg_height = region
         size, code = self.ctx.display.add_qr_frame(code)
-        # starting size is the amount of blocks per line
         max_width = self.ctx.display.width()
-        # scale is how many pixels per block
-        scale = max_width // size
-        qr_width = size * scale
-        offset = (max_width - qr_width) // 2
+        if zoom:
+            max_width -= DEFAULT_PADDING
+            if size == 23:  # 21 + 2(frame)
+                qr_size = 7
+            else:
+                qr_size = 5
+            offset_x = 0
+            offset_y = 0
+        else:
+            qr_size = size
+            offset_x = reg_x + 1
+            offset_y = reg_y + 1
+
+        scale = max_width // qr_size
+        qr_width = qr_size * scale
+        offset = (self.ctx.display.width() - qr_width) // 2
         for y in range(reg_height):  # vertical blocks loop
             for x in range(reg_width):  # horizontal blocks loop
                 xy_index = (reg_y + y + 1) * (size + 1)
                 xy_index += reg_x + x + 1
                 if code[xy_index] == "0":
                     self.ctx.display.fill_rectangle(
-                        offset + (reg_x + x + 1) * scale,
-                        offset + (reg_y + y + 1) * scale,
+                        offset + (offset_x + x) * scale,
+                        offset + (offset_y + y) * scale,
                         scale,
                         scale,
                         lcd.WHITE,

--- a/src/krux/pages/home.py
+++ b/src/krux/pages/home.py
@@ -230,12 +230,6 @@ class Home(Page):
             code, qr_size = self._seed_qr()
             label = t("SeedQR")
         label += t("\nSwipe to change mode")
-        if self.ctx.input.touch is not None:
-            self.ctx.display.draw_hcentered_text(
-                label,
-                self.ctx.display.qr_offset() + self.ctx.display.font_height,
-                color=lcd.WHITE,
-            )
         mode = 0
         lr_index = 0
         region_size = 7 if qr_size == 21 else 5
@@ -243,6 +237,12 @@ class Home(Page):
         button = None
         while button not in (SWIPE_DOWN, SWIPE_UP):
             draw_grided_qr(mode, qr_size)
+            if self.ctx.input.touch is not None:
+                self.ctx.display.draw_hcentered_text(
+                    label,
+                    self.ctx.display.qr_offset() + self.ctx.display.font_height,
+                    color=lcd.WHITE,
+                )
             # # Avoid the need of double click
             # self.ctx.input.buttons_active = True
             button = self.ctx.input.wait_for_button()

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -479,7 +479,7 @@ class Login(Page):
         index, _ = submenu.run_loop()
         w24 = index == 1
         self.ctx.display.clear()
-        
+
         tiny_seed = TinySeed(self.ctx)
         words = tiny_seed.enter_tiny_seed(w24)
         del tiny_seed
@@ -499,7 +499,7 @@ class Login(Page):
         index, _ = submenu.run_loop()
         w24 = index == 1
         self.ctx.display.clear()
-        
+
         intro = t(
             "Paint punched dots black so they can be detected. "
             + "Use a black background surface. "

--- a/src/krux/printers/thermal.py
+++ b/src/krux/printers/thermal.py
@@ -64,7 +64,7 @@ class AdafruitPrinter(Printer):
 
         self.character_height = 24
         self.byte_time = 1  # miliseconds
-        self.dot_print_time = 10  # miliseconds
+        self.dot_print_time = Settings().printer.thermal.adafruit.line_delay
         self.dot_feed_time = 2  # miliseconds
 
         self.setup()
@@ -108,7 +108,7 @@ class AdafruitPrinter(Printer):
         self.write_bytes(
             27,  # Esc
             55,  # 7 (print settings)
-            Settings().printer.thermal.adafruit.heat_dots,
+            11,  # Heat dots
             Settings().printer.thermal.adafruit.heat_time,
             Settings().printer.thermal.adafruit.heat_interval,
         )
@@ -184,7 +184,8 @@ class AdafruitPrinter(Printer):
             size += 1
 
         scale = Settings().printer.thermal.adafruit.paper_width // size
-        scale //= 3
+        scale *= Settings().printer.thermal.adafruit.scale
+        scale //= 200  # 100*2 because printer will scale 2X later to save data 
         # Maximum size is //2 Command will scale up by 2x later
         # Being at full size sometimes makes prints more faded (can't apply too much heat?)
 

--- a/src/krux/printers/thermal.py
+++ b/src/krux/printers/thermal.py
@@ -185,8 +185,7 @@ class AdafruitPrinter(Printer):
 
         scale = Settings().printer.thermal.adafruit.paper_width // size
         scale *= Settings().printer.thermal.adafruit.scale
-        scale //= 200  # 100*2 because printer will scale 2X later to save data 
-        # Maximum size is //2 Command will scale up by 2x later
+        scale //= 200  # 100*2 because printer will scale 2X later to save data
         # Being at full size sometimes makes prints more faded (can't apply too much heat?)
 
         line_bytes_size = (size * scale + 7) // 8  # amount of bytes per line


### PR DESCRIPTION
I've made some changes to improve thermal printing speed and reliability.
Most of Krux users from Telegram group who have thermal printers and I have gojprt qr203 model. The code works fine with it. One has gojprt qr204 model, which seems to have an issue with buffer (lost bytes), so I added the `scale` and `line delay`(speed) that help solve the issue. No one there has the Adafruit printer, so @jreesun could you test the thermal prints on it?
Other finding: Reducing scale can make blacks darker, I believe some printers/power supplies may have power limitations.
As all Krux users printers use 11 `heat dots`, I removed this config so all others fit in one screen in Amigo.