### PR TITLE
Changes atop commit 0752bcf intended so that tests pass

### DIFF
--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -256,7 +256,7 @@ def test_mnemonic_standard_qr(mocker, m5stickv, tdata):
         home = Home(ctx)
 
         mocker.spy(home, "display_qr_codes")
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
         home.mnemonic()
 
         title = "Plaintext QR"
@@ -264,7 +264,7 @@ def test_mnemonic_standard_qr(mocker, m5stickv, tdata):
             ctx.wallet.key.mnemonic, FORMAT_NONE, title
         )
         if case[1] is not None:
-            home.print_standard_qr.assert_called_with(
+            home.utils.print_standard_qr.assert_called_with(
                 ctx.wallet.key.mnemonic, FORMAT_NONE, title
             )
         assert ctx.input.wait_for_button.call_count == len(case[2])
@@ -485,7 +485,7 @@ def test_mnemonic_st_qr_touch(mocker, amigo_tft, tdata):
         home = Home(ctx)
 
         mocker.spy(home, "display_qr_codes")
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
 
         home.mnemonic()
 
@@ -494,7 +494,7 @@ def test_mnemonic_st_qr_touch(mocker, amigo_tft, tdata):
             ctx.wallet.key.mnemonic, FORMAT_NONE, title
         )
         if case[1] is not None:
-            home.print_standard_qr.assert_called_with(
+            home.utils.print_standard_qr.assert_called_with(
                 ctx.wallet.key.mnemonic, FORMAT_NONE, title
             )
 
@@ -575,7 +575,7 @@ def test_public_key(mocker, m5stickv, tdata):
         home = Home(ctx)
 
         mocker.spy(home, "display_qr_codes")
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
 
         home.public_key()
 
@@ -602,7 +602,7 @@ def test_public_key(mocker, m5stickv, tdata):
         ]
         home.display_qr_codes.assert_has_calls(display_qr_calls)
         if case[1] is not None:
-            home.print_standard_qr.assert_has_calls(print_qr_calls)
+            home.utils.print_standard_qr.assert_has_calls(print_qr_calls)
 
         assert ctx.input.wait_for_button.call_count == len(case[2])
 
@@ -694,7 +694,7 @@ def test_wallet(mocker, m5stickv, tdata):
             "display_qr_codes",
             new=lambda data, qr_format, title=None: ctx.input.wait_for_button(),
         )
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
         mocker.spy(home, "capture_qr_code")
         mocker.spy(home, "display_wallet")
 
@@ -702,7 +702,7 @@ def test_wallet(mocker, m5stickv, tdata):
 
         if case[0]:
             home.display_wallet.assert_called_once()
-            home.print_standard_qr.assert_called_once()
+            home.utils.print_standard_qr.assert_called_once()
         else:
             if case[4][0] == BUTTON_ENTER:
                 home.capture_qr_code.assert_called_once()
@@ -997,7 +997,7 @@ def test_sign_psbt(mocker, m5stickv, tdata):
         )
         mocker.spy(home, "capture_qr_code")
         mocker.spy(home, "display_qr_codes")
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
         # case SD available
         if case[10] is not None:
             mocker.patch("os.listdir", new=mocker.MagicMock(return_value=["test.psbt"]))
@@ -1024,7 +1024,7 @@ def test_sign_psbt(mocker, m5stickv, tdata):
                     home.capture_qr_code.assert_called_once()
                 if case[5]:  # signed!
                     home.display_qr_codes.assert_called_once()
-                    home.print_standard_qr.assert_called_once()
+                    home.utils.print_standard_qr.assert_called_once()
                 else:
                     home.display_qr_codes.assert_not_called()
             else:
@@ -1176,7 +1176,7 @@ def test_sign_message(mocker, m5stickv, tdata):
             "display_qr_codes",
             new=lambda data, qr_format, title=None: ctx.input.wait_for_button(),
         )
-        mocker.spy(home, "print_standard_qr")
+        mocker.spy(home.utils, "print_standard_qr")
         mocker.spy(home, "capture_qr_code")
         mocker.spy(home, "display_qr_codes")
         if case[6] is not None:
@@ -1203,7 +1203,7 @@ def test_sign_message(mocker, m5stickv, tdata):
                     mocker.call(case[5], case[1], "Hex Public Key"),
                 ]
             )
-            home.print_standard_qr.assert_has_calls(
+            home.utils.print_standard_qr.assert_has_calls(
                 [
                     mocker.call(case[4], case[1], "Signed Message"),
                     mocker.call(case[5], case[1], "Hex Public Key"),
@@ -1211,6 +1211,6 @@ def test_sign_message(mocker, m5stickv, tdata):
             )
         else:
             home.display_qr_codes.assert_not_called()
-            home.print_standard_qr.assert_not_called()
+            home.utils.print_standard_qr.assert_not_called()
 
         assert ctx.input.wait_for_button.call_count == len(case[3])

--- a/tests/pages/test_home.py
+++ b/tests/pages/test_home.py
@@ -672,7 +672,7 @@ def test_wallet(mocker, m5stickv, tdata):
             tdata.MULTISIG_12_WORD_KEY,
             tdata.SPECTER_MULTISIG_WALLET_DATA,
             None,
-            [BUTTON_ENTER, BUTTON_ENTER],
+            [BUTTON_ENTER, BUTTON_ENTER, BUTTON_ENTER],
         ),
     ]
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -73,7 +73,7 @@ def test_screensaver(mocker, m5stickv):
         ██ ██
         ██  ██
         ██   ██
-        """[
+"""[
         1:-1
     ].split(
         "\n"
@@ -94,7 +94,7 @@ def test_screensaver(mocker, m5stickv):
     time_seq.append(tmp)
     btn_seq.append(BUTTON_ENTER)
 
-    c.input.wait_for_press = mocker.MagicMock(side_effect=btn_seq)
+    c.input.wait_for_button = mocker.MagicMock(side_effect=btn_seq)
     time.ticks_ms = mocker.MagicMock(side_effect=time_seq)
 
     c.screensaver()
@@ -105,4 +105,4 @@ def test_screensaver(mocker, m5stickv):
     c.display.draw_line_hcentered_with_fullw_bg.assert_any_call(
         logo[5], 5, theme.bg_color, theme.fg_color
     )
-    c.input.wait_for_press.assert_called()
+    c.input.wait_for_button.assert_called()


### PR DESCRIPTION
I'm just taking baby-steps with some 'harmless' (I hope) tests changes, but mostly so that I can have feedback where I've missed the more correct solution.

* 1st commit feels safe, print_standard_qr() is now in utils.Utils.
* 2nd commit, not sure if it's a solution, or if it's disguising an error, because I'm not able to locate which "wait_for_something" prompt was added that makes an extra `<enter>` necessary.
* 3rd commit feels safe, screensaver waits for button instead of press, however I also altered the setting of "logo" variable because I assume that the [1:-1] slice notation was meant to strip the '\n' chars that are first and last, instead of only stripping one last space among others that would not be stripped.  I also considered expressing it like "logo string".split('\n')[1:-1] so that it's expressively stripping first and last blank lines.