### PR TITLE
Ci issues and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,11 @@
+---
+
+name: 🐞 Bug report
+about: Create a report to help us improve
+title: "[Bug] the title of bug report"
+labels: bug
+assignees: ''
+
+---
+
+#### Describe the bug

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,10 @@
+---
+name: 🔥 Enhancement
+about: New feature or request
+title: "[Enhancement] the title of new feature or enhancement"
+labels: enhancement
+assignees: ''
+
+---
+
+#### Describe the new feature or enhancement

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,0 +1,10 @@
+---
+name: 🥺 Help wanted
+about: Confuse about the use of ksigner
+title: "[Help] the title of help wanted report"
+labels: help wanted
+assignees: ''
+
+---
+
+#### Describe the problem you confuse

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,6 +1,6 @@
 ---
 name: 🥺 Help wanted
-about: Confuse about some krux usage
+about: Help needed to use a feature, perform or understand a procedure
 title: "[Help] the title of help wanted report"
 labels: help wanted
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/help_wanted.md
+++ b/.github/ISSUE_TEMPLATE/help_wanted.md
@@ -1,10 +1,10 @@
 ---
 name: 🥺 Help wanted
-about: Confuse about the use of ksigner
+about: Confuse about some krux usage
 title: "[Help] the title of help wanted report"
 labels: help wanted
 assignees: ''
 
 ---
 
-#### Describe the problem you confuse
+#### Describe the problem you need help

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Thank you for contributing! -->
+
+### Description
+
+<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
+
+### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->
+
+- [ ] Bug fix
+- [ ] New Feature
+- [ ] Documentation update
+- [ ] Other


### PR DESCRIPTION
Added some templates for adding new tagged issues and PRs. Useful for:

- When a developer or krux user click to create a new issue, it will open a new page with a stylished issue with automatic tags like `bug`, `enhancement` or `help_wanted` (see [this example](https://github.com/selfcustody/krux-file-signer/issues/new/choose))

- When a developer create a new PR, it will open an already created text with selectors (about which change he/she made) and a `Description` space to talk about it.