### PR TITLE
Reduced settings writes without defaults

### DIFF
--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -25,7 +25,7 @@ from ..themes import theme, RED, GREEN, ORANGE, MAGENTA
 from ..settings import (
     CategorySetting,
     NumberSetting,
-    Store,
+    store,
     SD_PATH,
     FLASH_PATH,
     SETTINGS_FILENAME,
@@ -230,14 +230,29 @@ class SettingsPage(Page):
             try:
                 # Check for SD hot-plug
                 with SDHandler():
-                    Store.save_settings()
-                    self._display_centered_text(
-                        t("Changes persisted to SD card!"),
-                        duration=SD_MSG_TIME,
-                    )
+                    if store.save_settings():
+                        self._display_centered_text(
+                            t("Changes persisted to SD card!"),
+                            duration=SD_MSG_TIME,
+                        )
             except OSError:
                 self._display_centered_text(
                     t("SD card not detected.")
+                    + "\n\n"
+                    + t("Changes will last until shutdown."),
+                    duration=SD_MSG_TIME,
+                )
+        else:
+            self.ctx.display.clear()
+            try:
+                if store.save_settings():
+                    self._display_centered_text(
+                        t("Changes persisted to Flash!"),
+                        duration=SD_MSG_TIME,
+                    )
+            except:
+                self._display_centered_text(
+                    t("Unexpected error saving to Flash.")
                     + "\n\n"
                     + t("Changes will last until shutdown."),
                     duration=SD_MSG_TIME,
@@ -370,7 +385,7 @@ class SettingsPage(Page):
                 # Restore previous theme
                 setting.__set__(settings_namespace, starting_category)
                 theme.update()
-                Store.save_settings()
+                store.save_settings()
 
         return MENU_CONTINUE
 

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -75,6 +75,8 @@ class Setting:
         return store.get(obj.namespace, self.attr, self.default_value)
 
     def __set__(self, obj, value):
+        if self.attr == "location":
+            store.update_file_location(value)
         store.set(obj.namespace, self.attr, value)
 
 
@@ -101,6 +103,7 @@ class Store:
     def __init__(self):
         self.settings = {}
         self.file_location = "/" + FLASH_PATH + "/"
+        self.dirty = False
 
         # Check for the correct settings persist location
         try:
@@ -144,39 +147,54 @@ class Store:
         return s[setting_name]
 
     def set(self, namespace, setting_name, setting_value):
-        """Stores a setting value under the given namespace. We don't use SDHandler
-        here because set is called too many times every time the user changes a setting
-        and SDHandler remount causes a small delay
+        """Stores a setting value under the given namespace if new/changed.
+        Does NOT automatically save settings to flash or sd!
         """
         s = self.settings
         for level in namespace.split("."):
             s[level] = s.get(level, {})
             s = s[level]
         old_value = s.get(setting_name, None)
-        s[setting_name] = setting_value
+        if old_value != setting_value:
+            s[setting_name] = setting_value
+            self.dirty = True
 
-        # if is a change in settings persist location, delete file from old location,
-        # and later it will save on the new location
-        if setting_name == "location" and old_value:
-            # update the file location
-            self.file_location = "/" + setting_value + "/"
+    def update_file_location(self, location):
+        """Assumes settings.persist.location will be changed to location:
+        tries to delete current persistent settings file
+        then updates file_location attribute
+        """
+        if "/" + location + "/" != self.file_location:
             try:
-                # remove old SETTINGS_FILENAME
-                os.remove("/" + old_value + "/" + SETTINGS_FILENAME)
+                if os.stat(self.file_location + SETTINGS_FILENAME):
+                    os.remove(self.file_location + SETTINGS_FILENAME)
             except:
                 pass
+            self.file_location = "/" + location + "/"
 
-        Store.save_settings()
-
-    @staticmethod
-    def save_settings():
+    def save_settings(self):
         """Helper to persist SETTINGS_FILENAME where user selected"""
-        try:
-            # save the new SETTINGS_FILENAME
-            with open(store.file_location + SETTINGS_FILENAME, "w") as f:
-                f.write(json.dumps(store.settings))
-        except:
-            pass
+        persisted = False
+
+        if self.dirty:
+            settings_filename = self.file_location + SETTINGS_FILENAME
+            new_contents = json.dumps(self.settings)
+            try:
+                with open(settings_filename, "r") as f:
+                    old_contents = f.read()
+            except:
+                old_contents = None
+
+            if new_contents != old_contents:
+                try:
+                    with open(settings_filename, "w") as f:
+                        f.write(new_contents)
+                    persisted = True
+                except:
+                    pass
+            self.dirty = False
+
+        return persisted
 
 
 # Initialize singleton


### PR DESCRIPTION
Building on top of #295, this pr (arguably more dangerous) alters the settings.Store structure so that default values and their empty namespaces are never stored in settings.json.

* krux.settings.Setting.set still calls store.set() but only for custom settings, it will call store.delete() for defaults -- to clean-up the store
* krux.settings.Store.get no longer builds-out the settings dictionary, works with a deepcopy instead
* krux.settings.Store.delete is used to remove default values and empty parent namespaces
* an all-defaults settings.json file will contain an empty dict "{}"
* adds new tests and adjusts existing tests.