### PR TITLE
Issues templates and dependabot configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+
+name:  ✍  Add documentation
+about: Improvements or additions to documentation
+title: "[Documentation] the title of documentation"
+labels: documentation
+assignees: ''
+
+---
+
+#### Describe the improvement or additions to documentation

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,11 @@
+---
+
+name:  ⚡ Good first issue
+about: Good for newcomers
+title: "[Good first issue] the title of the good first issue"
+labels: good first issue
+assignees: ''
+
+---
+
+#### Describe the good first issue

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+
+name:  🙋 Question
+about: Further information is requested
+title: "[Question] the title of the question"
+labels: question
+assignees: ''
+
+---
+
+#### Describe the question

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  
+  # Maintain dependencies for GitHub Actions.
+  # Dependabot will raise pull requests
+  # for version updates for any outdated actions that it finds.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      
+  # Maintain dependencies for python packages.
+  # Dependabot will raise pull requests
+  # for version updates for any outdated package that it finds.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  


### PR DESCRIPTION
### Description

This PR adds 3 more Issue templates (`documentation`, `good first issue` and `question`) and a dependabot.yml configuration to check for updates for used github-actions and pip packages.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other: issue templates and dependabot for CI/CD
