### PR TITLE
seeds.json on sdcard padded to avoid abandoned bytes

### DIFF
--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -155,7 +155,6 @@ class MnemonicStorage:
                     mnemonics = json.loads(contents)
             except:
                 orig_len = 0
-                pass
 
             # save the new MNEMONICS_FILE
             try:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Related to issue #299

### Description
On an sdcard's FAT filesystem, when a file grows into additional sectors and is later trimmed, bytes will remain abandoned in previously used sectors.  For `seeds.json`, which holds encrypted mnemonics, this is less than ideal because it could result in ciphertext with weak encryption keys remaining on the sdcard media yet hidden from plain sight for the user.

This pr alters krux.encryption.MnemonicStorage's `.store_encrypted()` and `.del_mnemonic` methods so that `seeds.json` gets padded with spaces -- to its original size.  That is, it will never be trimmed.  Care elsewhere should be taken so that `os.remove()` is not used for `seeds.json`, as it abandons all bytes.

CAUTION: This pr may create a false-sense-of-security in the event that it fails to work, and it certainly can do NOTHING to save the user from themself if they choose to edit/remove seeds.json from the microsd outside of krux.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
