### PR TITLE
Fix build error when files with Windows line ending CRLF (\r\n)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,4 +110,5 @@ FROM build-firmware AS build
 ARG DEVICE="maixpy_m5stickv"
 WORKDIR /src/firmware/Kboot/build
 RUN cp /src/firmware/MaixPy/projects/"${DEVICE}"/build/firmware.bin .
+RUN sed -i -e 's/\r$//' *.sh
 RUN ./CLEAN.sh && ./BUILD.sh

--- a/krux
+++ b/krux
@@ -55,7 +55,7 @@ if [ "$1" == "build" ]; then
     if [ -z "$device" ]; then
         echo "Missing device"
     else
-        declare $(grep -m 1 version pyproject.toml | sed 's/ *= */=/g' | sed 's/"//g')
+        declare $(grep -m 1 version pyproject.toml | sed 's/ *= */=/g' | sed 's/"//g' | sed 's/\r//g')
         sed -i -- 's/VERSION = ".*"/VERSION = "'"$version"'"/g' src/krux/metadata.py
 
         mkdir -p build


### PR DESCRIPTION
### Description

When git is installed on Windows it uses as default CRFL (\r\n) line endings, and this break the build process. This commit fixes that

More info: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
