### PR TITLE
Wallet customization: Account "Number" becomes "Index"

### DIFF
--- a/src/krux/key.py
+++ b/src/krux/key.py
@@ -45,18 +45,18 @@ class Key:
         multisig,
         network=NETWORKS["test"],
         passphrase="",
-        account_number=0,
+        account=0,
     ):
         self.mnemonic = mnemonic
         self.multisig = multisig
         self.network = network
-        self.account_number = account_number
+        self.account_index = account
         self.root = bip32.HDKey.from_seed(
             bip39.mnemonic_to_seed(mnemonic, passphrase), version=network["xprv"]
         )
         self.fingerprint = self.root.child(0).fingerprint
         self.derivation = self.get_default_derivation(
-            self.multisig, network, account_number
+            self.multisig, self.network, self.account_index
         )
         self.account = self.root.derive(self.derivation).to_public()
 
@@ -130,17 +130,17 @@ class Key:
                 return word
 
     @staticmethod
-    def get_default_derivation(multisig, network, account_number=0):
+    def get_default_derivation(multisig, network, account=0):
         """Return the Krux default derivation path for single-sig or multisig"""
         if multisig:
             return DER_MULTI % network["bip32"]
-        return DER_SINGLE % (network["bip32"], account_number)
+        return DER_SINGLE % (network["bip32"], account)
 
     @staticmethod
-    def get_default_derivation_str(multisig, network, account_number=0):
+    def get_default_derivation_str(multisig, network, account=0):
         """Return the Krux default derivation path for single-sig or multisig to
         be displayd as string
         """
         return "↳ " + Key.get_default_derivation(
-            multisig, network, account_number
+            multisig, network, account
         ).replace("h", HARDENED_STR_REPLACE)

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -101,7 +101,7 @@ class Home(Page):
                 self.ctx.wallet.key.multisig,
                 self.ctx.wallet.key.network,
                 passphrase,
-                self.ctx.wallet.key.account_number,
+                self.ctx.wallet.key.account_index,
             )
         )
         return MENU_CONTINUE
@@ -123,7 +123,7 @@ class Home(Page):
         from ...wallet import Wallet
 
         wallet_settings = WalletSettings(self.ctx)
-        network, multisig, script_type, account_number = (
+        network, multisig, script_type, account = (
             wallet_settings.customize_wallet(self.ctx.wallet.key)
         )
         mnemonic = self.ctx.wallet.key.mnemonic
@@ -133,7 +133,7 @@ class Home(Page):
                 multisig,
                 network,
                 "",
-                account_number,
+                account,
             )
         )
         return MENU_CONTINUE

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -223,7 +223,7 @@ class Login(Page):
         passphrase = ""
         multisig = Settings().wallet.multisig
         network = NETWORKS[Settings().wallet.network]
-        account_number = 0
+        account = 0
         from ..wallet import Wallet
 
         while True:
@@ -232,7 +232,7 @@ class Login(Page):
                 multisig,
                 network,
                 passphrase,
-                account_number,
+                account,
             )
 
             wallet_info = key.fingerprint_hex_str(True) + "\n"
@@ -274,7 +274,7 @@ class Login(Page):
                 from .wallet_settings import WalletSettings
 
                 wallet_settings = WalletSettings(self.ctx)
-                network, multisig, script_type, account_number = (
+                network, multisig, script_type, account = (
                     wallet_settings.customize_wallet(key)
                 )
 

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -37,7 +37,7 @@ from . import (
 from .settings_page import DIGITS
 
 PASSPHRASE_MAX_LEN = 200
-ACCOUNT_MAX = 2**31 - 1  # Maximum account number
+ACCOUNT_MAX = 2**31 - 1  # Maximum account index
 
 
 class PassphraseEditor(Page):
@@ -100,14 +100,14 @@ class WalletSettings(Page):
         network = key.network
         multisig = key.multisig
         script_type = "84"  # TODO: Add script type selection
-        account_number = key.account_number
+        account = key.account_index
         while True:
             derivation_path = "m/"
             derivation_path += "'/".join(
                 [
                     "48" if multisig else script_type,
                     "0" if network == NETWORKS["main"] else "1",
-                    str(account_number) + "'" if not multisig else "0'",
+                    str(account) + "'" if not multisig else "0'",
                 ]
             )
             if multisig:
@@ -143,10 +143,10 @@ class WalletSettings(Page):
             elif index == 2:
                 script_type = value
             elif index == 3:
-                account_temp = self._account_number(account_number)
+                account_temp = self._account(account)
                 if account_temp is not None:
-                    account_number = account_temp
-        return network, multisig, script_type, account_number
+                    account = account_temp
+        return network, multisig, script_type, account
 
     def _coin_type(self):
         """Network selection menu"""
@@ -189,24 +189,24 @@ class WalletSettings(Page):
         _, purpose = submenu.run_loop()
         return purpose
 
-    def _account_number(self, initial_account_number=None):
-        """Account number input"""
+    def _account(self, initial_account=None):
+        """Account input"""
         account = self.capture_from_keypad(
-            t("Account Number"),
+            t("Account Index"),
             [DIGITS],
             starting_buffer=(
-                str(initial_account_number)
-                if initial_account_number is not None
+                str(initial_account)
+                if initial_account is not None
                 else ""
             ),
         )
         if account == ESC_KEY:
             return None
         try:
-            account_number = int(account)
-            if account_number > ACCOUNT_MAX:
+            account = int(account)
+            if account > ACCOUNT_MAX:
                 raise ValueError
         except:
             self.flash_text(t("Insert an account between 0 and %d") % ACCOUNT_MAX)
             return None
-        return account_number
+        return account


### PR DESCRIPTION
### Description

Only one ux change when customizing wallet:
* "Account Number" becomes "Account Index" (since the count starts at 0)

Many lines of code changes (no functional change) to clarify and/or simplify:
* `account_number` names simplified to `account` mostly for local variable names when not confusing.
* `account_number` changed to `account_index` where it needed to be explicit, because `account` is already an embit key.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
Just a picky edit towards naming conventions: so that 
* "number" specifies counting from 1 while a behind-the-scenes "number-1" is likely taking place, and 
* "index" specifies counting from 0, just like at the end of the derivation path.

Note: existing naming conventions already use "_number" for ints that start at 1 and "_index" for those that start at 0 (except for cnc code which uses "_idx").