### PR TITLE
Adjustments for taproot, one commit at a time, little by little

### DIFF
--- a/src/krux/psbt.py
+++ b/src/krux/psbt.py
@@ -105,8 +105,15 @@ class PSBTSigner:
         mismatched_paths = []
         der_path_nodes = len(self.wallet.key.derivation.split("/")) - 1
         for _input in self.psbt.inputs:
-            for pubkey in _input.bip32_derivations:
-                derivation_path = _input.bip32_derivations[pubkey].derivation
+            if self.policy["type"] == "p2tr":
+                derivations = _input.taproot_bip32_derivations
+            else:
+                derivations = _input.bip32_derivations
+            for pubkey in derivations:
+                if self.policy["type"] == "p2tr":
+                    derivation_path = derivations[pubkey][1].derivation # ignore taproot leaf
+                else:
+                    derivation_path = derivations[pubkey].derivation
                 textual_path = "m"
                 for index in derivation_path[:der_path_nodes]:
                     if index >= 2**31:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
DRAFT:  Adjustments for taproot:

* support for taproot in PSBTSigner.path_mismatch() to catch krux's wallet on wrong purpose/network/account
(derivations are a different structure and a different key for p2tr)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
