### PR TITLE
Fix dockerfile build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ simulator/sd
 # allow files: firmware.bin, .sig, .sha256.txt
 !tests/*
 !tests/files/*
+
+# ignore build-release files
+krux-*/ktool*

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,9 @@ RUN apt-get update -y && \
         python3-setuptools
 
 RUN mkdir -p /opt && \
-    git clone --recursive https://github.com/kendryte/kendryte-gnu-toolchain && \
-    cd kendryte-gnu-toolchain && \
-    git checkout fbf55383711b68c00ecf67e23959822180010398 && \
+    git clone --depth 1 --recurse-submodules --shallow-submodules --branch v8.2.0-20190409 https://github.com/kendryte/kendryte-gnu-toolchain
+
+RUN cd kendryte-gnu-toolchain && \
     export PATH=$PATH:/opt/kendryte-toolchain/bin && \
     ./configure --prefix=/opt/kendryte-toolchain --with-cmodel=medany --with-arch=rv64imafc --with-abi=lp64f --enable-threads=posix --enable-libatomic && \
     make -j8

--- a/README.md
+++ b/README.md
@@ -53,24 +53,16 @@ To build and flash the firmware:
 
 The first time, the build can take around an hour or so to complete. Subsequent builds should take only a few minutes. If all goes well, you should see a new `build` folder containing `firmware.bin` and `kboot.kfpkg` files when the build completes.
 
-Note: if you encounter any of these errors while building, it is a problem connecting to github, try again (if the error persists, try changing the DNS/VPN or correcting the hostname resolution of github.com to an IP that is working for you):
-```
-error: RPC failed; curl 92 HTTP/2 stream 0 was not closed cleanly: CANCEL (err8)
-fatal: the remote end hung up unexpectedly
-fatal: early EOF
-fatal: index-pack failed
-fatal: clone of ... failed
-Failed to clone ...
-```
-
 ## Install Krux and dev tools
 Krux uses [Poetry](https://python-poetry.org/) as Python packaging and dependency management. This cmd installs development dependencies like [embit](https://github.com/diybitcoinhardware/embit), [ur](https://github.com/selfcustody/foundation-ur-py) and [urtypes](https://github.com/selfcustody/urtypes), and tools to run [tests](https://docs.pytest.org), review code with [pylint](https://pypi.org/project/pylint/), format code with [black](https://github.com/psf/black) and a lib to help handle i18n translations.
 ```bash
 pip install poetry
 poetry install
 ```
-If you have a problem installing Poetry on Linux OS try (we consider the name of the venv .krux but you can change this...):
+
+If you have a problem installing Poetry on Linux OS:
 ```bash
+# we considered the name of the venv .krux
 python -m venv .krux
 source .krux/bin/activate
 ```


### PR DESCRIPTION
I had updated my Docker to the latest version (`Docker version 26.1.2, build 211e74b`) and my cache gone. I was having lots of issues with github on the clone step of the build process of the Dockerfile, now is permanently fixed!

This latest version of Docker resolved some issues with cache too, now the build process is lightning fast if you do a release for multiple devices for example.

To update your docker on Linux or WSL type `sudo apt-get update && sudo apt-get upgrade`, then to be sure, close WSL wait 2 to 3 minutes and open it again (this will force a complete restart of the WSL)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
