### PR TITLE
Avoid label overflow in numeral_settings

### DIFF
--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -400,7 +400,7 @@ class SettingsPage(Page):
             numerals += "."
 
         new_value = self.capture_from_keypad(
-            settings_namespace.label(setting.attr),
+            self.fit_to_line(settings_namespace.label(setting.attr)),
             [numerals],
             starting_buffer=str(starting_value),
             esc_prompt=False,


### PR DESCRIPTION
Fix rare overflow of labels in numeral_settings. Ex.: pt-BR "Tempo para protetor de tela"

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
