### PR TITLE
sorted directory listings in filemanager

### DIFF
--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -64,7 +64,7 @@ class FileManager(Page):
                     menu_items.append(("..", lambda: MENU_EXIT))
 
                 dir_files = os.listdir(path)
-                for filename in dir_files:
+                for filename in sorted(dir_files):
                     extension_match = False
                     if isinstance(file_extension, str):
                         # No extension filter or matches


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Working in another branch where I had added many files to the sdcard, I noticed that directory listings were not sorted.  This commit sorts directory listings (naive sort) for the file manager only.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
