### PR TITLE
avoid prompt (made redundant by submenu choice).

### DIFF
--- a/src/krux/pages/home_pages/wallet_descriptor.py
+++ b/src/krux/pages/home_pages/wallet_descriptor.py
@@ -93,7 +93,7 @@ class WalletDescriptor(Page):
 
                 utils = Utils(self.ctx)
                 _, wallet_data = utils.load_file(
-                    (DESCRIPTOR_FILE_EXTENSION, JSON_FILE_EXTENSION)
+                    (DESCRIPTOR_FILE_EXTENSION, JSON_FILE_EXTENSION), prompt=False
                 )
                 persisted = True
             except OSError:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This avoids a single prompt "Load from SD card?" when loading a wallet descriptor from sdcard because a new submenu offering ("Load from camera", "Load from SD crd", "Back") makes this prompt redundant.
The prompt was previously required because the flow was sequentially to 1) scan via camera and 2) load from sdcard (but maybe user just wants to try scanning from camera again).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
