### PR TITLE
Show sorted directories first in SD filemanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,12 @@ Use [MaixPy IDE](https://dl.sipeed.com/shareURL/MAIX/MaixPy/ide/v0.2.5) to debug
 ## WDT watchdog
 Krux makes use of MaixPy's [WDT watchdog module](https://wiki.sipeed.com/soft/maixpy/en/api_reference/machine/wdt.html), you can see it [here](src/krux/wdt.py). This will reset the device if not fed for some time. To stop the watchdog, when connected through the terminal, run the following:
 ```python
-# This will read the board config file, add the config to disable watchdog, save the new config file and reset the device (in order to make krux read the new file!)
+# Run this everytime you want to stop the watchdog
+
+from krux.wdt import wdt
+wdt.stop()
+
+# OR create this config to disable the watchdog, save the settings file and reset the device (in order to make krux read the new file!)
 
 import json, machine
 

--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -63,8 +63,23 @@ class FileManager(Page):
                     items.append("..")
                     menu_items.append(("..", lambda: MENU_EXIT))
 
-                dir_files = os.listdir(path)
-                for filename in sorted(dir_files):
+                # sorts by name ignorecase
+                dir_files = sorted(os.listdir(path), key=str.lower)
+
+                # separate directories from files
+                directories = []
+                files = []
+
+                for filename in dir_files:
+                    if SDHandler.file_exists(path + "/" + filename):
+                        files.append(filename)
+                    else:
+                        directories.append(filename)
+
+                del dir_files
+
+                # show sorted folders first than sorted files
+                for filename in directories + files:
                     extension_match = False
                     if isinstance(file_extension, str):
                         # No extension filter or matches


### PR DESCRIPTION
- SD file listing now shows sorted folders first than files for better navigability
- Sorting ignores case (like when sorting a folder in Windows)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
