### PR TITLE
.persisted as boolean: initialized False (instead of None)

### DIFF
--- a/src/krux/pages/home_pages/wallet_descriptor.py
+++ b/src/krux/pages/home_pages/wallet_descriptor.py
@@ -81,7 +81,7 @@ class WalletDescriptor(Page):
 
     def _load_wallet(self):
 
-        persisted = None
+        persisted = False
         load_method = self.load_method()
         if load_method == LOAD_FROM_CAMERA:
             wallet_data, qr_format = self.capture_qr_code()

--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -50,7 +50,7 @@ class Wallet:
         self.descriptor = None
         self.label = None
         self.policy = None
-        self.persisted = None
+        self.persisted = False
         self._network = None
         if self.key and not self.key.multisig:
             if self.key.script_type == P2PKH:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Related to pr #388 and suggestions from Tadeu:

`wallet.persisted` is being used as a boolean but was initialized to None.  This pr corrects treatment of `.persisted` as a boolean, initializing it to False until krux knows that the descriptor is truly persisted.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
