### PR TITLE
Adds "< " to "Back" menu items

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -912,6 +912,6 @@ def choose_len_mnemonic(ctx):
     return num_words
 
 
-def cta_back(status=MENU_EXIT, tlabel="Back"):
+def cta_back(status=MENU_EXIT, label=t("Back")):
     """Reusable 'call-to-action: go back'.  Currently a menu item tuple"""
-    return ("< " + t(tlabel), lambda: status)
+    return ("< " + label, lambda: status)

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -109,7 +109,7 @@ class Page:
                     t("Load from SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: None),
             ],
         )
         index, _ = load_menu.run_loop()
@@ -902,15 +902,11 @@ def choose_len_mnemonic(ctx):
     submenu = Menu(
         ctx,
         [
-            (t("12 words"), lambda: MENU_EXIT),
-            (t("24 words"), lambda: MENU_EXIT),
-            ("< " + t("Back"), lambda: MENU_EXIT),
+            (t("12 words"), lambda: 12),
+            (t("24 words"), lambda: 24),
+            ("< " + t("Back"), lambda: None),
         ],
     )
-    index, _ = submenu.run_loop()
+    _, num_words = submenu.run_loop()
     ctx.display.clear()
-    if index == 0:
-        return 12
-    if index == 1:
-        return 24
-    return None
+    return num_words

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -109,7 +109,7 @@ class Page:
                     t("Load from SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                (t("Back"), lambda: None),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, _ = load_menu.run_loop()
@@ -904,7 +904,7 @@ def choose_len_mnemonic(ctx):
         [
             (t("12 words"), lambda: MENU_EXIT),
             (t("24 words"), lambda: MENU_EXIT),
-            (t("Back"), lambda: MENU_EXIT),
+            ("< " + t("Back"), lambda: MENU_EXIT),
         ],
     )
     index, _ = submenu.run_loop()

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -109,7 +109,7 @@ class Page:
                     t("Load from SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: None),
+                cta_back(None),
             ],
         )
         index, _ = load_menu.run_loop()
@@ -904,9 +904,14 @@ def choose_len_mnemonic(ctx):
         [
             (t("12 words"), lambda: 12),
             (t("24 words"), lambda: 24),
-            ("< " + t("Back"), lambda: None),
+            cta_back(None),
         ],
     )
     _, num_words = submenu.run_loop()
     ctx.display.clear()
     return num_words
+
+
+def cta_back(status=MENU_EXIT, tlabel="Back"):
+    """Reusable 'call-to-action: go back'.  Currently a menu item tuple"""
+    return ("< " + t(tlabel), lambda: status)

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -109,7 +109,7 @@ class Page:
                     t("Load from SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                cta_back(None),
+                cta_back(lambda: None),
             ],
         )
         index, _ = load_menu.run_loop()
@@ -904,7 +904,7 @@ def choose_len_mnemonic(ctx):
         [
             (t("12 words"), lambda: 12),
             (t("24 words"), lambda: 24),
-            cta_back(None),
+            cta_back(lambda: None),
         ],
     )
     _, num_words = submenu.run_loop()
@@ -912,6 +912,6 @@ def choose_len_mnemonic(ctx):
     return num_words
 
 
-def cta_back(status=MENU_EXIT, label=t("Back")):
+def cta_back(status=lambda: MENU_EXIT, label=t("Back")):
     """Reusable 'call-to-action: go back'.  Currently a menu item tuple"""
-    return ("< " + label, lambda: status)
+    return ("< " + label, status)

--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -22,7 +22,7 @@
 
 import board
 import gc
-from . import Page, Menu, MENU_EXIT, MENU_CONTINUE
+from . import Page, Menu, MENU_EXIT, MENU_CONTINUE, cta_back
 from ..sd_card import SDHandler
 from ..krux_settings import t
 from ..format import generate_thousands_separator, render_decimal_separator
@@ -115,7 +115,7 @@ class FileManager(Page):
 
                 # We need to add this option because /sd can be empty!
                 items.append("Back")
-                menu_items.append(("< " + t("Back"), lambda: MENU_EXIT))
+                menu_items.append(cta_back())
 
                 submenu = Menu(self.ctx, menu_items)
                 index, _ = submenu.run_loop()

--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -115,7 +115,7 @@ class FileManager(Page):
 
                 # We need to add this option because /sd can be empty!
                 items.append("Back")
-                menu_items.append((t("Back"), lambda: MENU_EXIT))
+                menu_items.append(("< " + t("Back"), lambda: MENU_EXIT))
 
                 submenu = Menu(self.ctx, menu_items)
                 index, _ = submenu.run_loop()

--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -29,6 +29,7 @@ from .. import (
     Menu,
     MENU_CONTINUE,
     MENU_EXIT,
+    cta_back,
 )
 
 SCAN_ADDRESS_LIMIT = 50
@@ -50,7 +51,7 @@ class Addresses(Page):
                 (t("Scan Address"), self.pre_scan_address),
                 (t("Receive Addresses"), self.list_address_type),
                 (t("Change Addresses"), lambda: self.list_address_type(1)),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()
@@ -102,7 +103,7 @@ class Addresses(Page):
                     lambda: MENU_EXIT,
                 )
             )
-            items.append(("< " + t("Back"), lambda: MENU_EXIT))
+            items.append(cta_back())
 
             submenu = Menu(self.ctx, items)
             stay_on_this_addr_menu = True
@@ -137,7 +138,7 @@ class Addresses(Page):
             [
                 (t("Receive"), self.scan_address),
                 (t("Change"), lambda: self.scan_address(1)),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()

--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -50,7 +50,7 @@ class Addresses(Page):
                 (t("Scan Address"), self.pre_scan_address),
                 (t("Receive Addresses"), self.list_address_type),
                 (t("Change Addresses"), lambda: self.list_address_type(1)),
-                (t("Back"), lambda: None),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()
@@ -102,7 +102,7 @@ class Addresses(Page):
                     lambda: MENU_EXIT,
                 )
             )
-            items.append((t("Back"), lambda: MENU_EXIT))
+            items.append(("< " + t("Back"), lambda: MENU_EXIT))
 
             submenu = Menu(self.ctx, items)
             stay_on_this_addr_menu = True
@@ -137,7 +137,7 @@ class Addresses(Page):
             [
                 (t("Receive"), self.scan_address),
                 (t("Change"), lambda: self.scan_address(1)),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -29,10 +29,10 @@ from .. import (
     Page,
     Menu,
     MENU_CONTINUE,
-    MENU_EXIT,
     ESC_KEY,
     LOAD_FROM_CAMERA,
     LOAD_FROM_SD,
+    cta_back,
 )
 
 MAX_POLICY_COSIGNERS_DISPLAYED = 5
@@ -169,7 +169,7 @@ class Home(Page):
                 (t("Passphrase"), self.passphrase),
                 (t("Customize"), self.customize),
                 ("BIP85", self.bip85),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()
@@ -189,7 +189,7 @@ class Home(Page):
             [
                 ("PSBT", self.sign_psbt),
                 (t("Message"), self.sign_message),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()
@@ -228,7 +228,7 @@ class Home(Page):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: None),
+                cta_back(None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -228,7 +228,7 @@ class Home(Page):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                cta_back(None),
+                cta_back(lambda: None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -228,7 +228,7 @@ class Home(Page):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -169,7 +169,7 @@ class Home(Page):
                 (t("Passphrase"), self.passphrase),
                 (t("Customize"), self.customize),
                 ("BIP85", self.bip85),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()
@@ -189,7 +189,7 @@ class Home(Page):
             [
                 ("PSBT", self.sign_psbt),
                 (t("Message"), self.sign_message),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()
@@ -228,7 +228,7 @@ class Home(Page):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                (t("Back"), lambda: None),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/mnemonic_backup.py
+++ b/src/krux/pages/home_pages/mnemonic_backup.py
@@ -42,7 +42,7 @@ class MnemonicsView(Page):
                 (t("QR Code"), self.qr_code_backup),
                 (t("Encrypted"), self.encrypt_mnemonic_menu),
                 (t("Other Formats"), self.other_backup_formats),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()
@@ -57,7 +57,7 @@ class MnemonicsView(Page):
                 ("Compact SeedQR", lambda: self.display_seed_qr(True)),
                 ("SeedQR", self.display_seed_qr),
                 (t("Encrypted QR Code"), self.encrypt_qr_code),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()
@@ -77,7 +77,7 @@ class MnemonicsView(Page):
                 (t("Numbers"), self.display_mnemonic_numbers),
                 ("Stackbit 1248", self.stackbit),
                 ("Tiny Seed", self.tiny_seed),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()
@@ -149,7 +149,7 @@ class MnemonicsView(Page):
                         Utils.BASE_OCT_SUFFIX,
                     ),
                 ),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         submenu.run_loop()

--- a/src/krux/pages/home_pages/mnemonic_backup.py
+++ b/src/krux/pages/home_pages/mnemonic_backup.py
@@ -27,7 +27,7 @@ from .. import (
     Page,
     Menu,
     MENU_CONTINUE,
-    MENU_EXIT,
+    cta_back,
 )
 
 
@@ -42,7 +42,7 @@ class MnemonicsView(Page):
                 (t("QR Code"), self.qr_code_backup),
                 (t("Encrypted"), self.encrypt_mnemonic_menu),
                 (t("Other Formats"), self.other_backup_formats),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()
@@ -57,7 +57,7 @@ class MnemonicsView(Page):
                 ("Compact SeedQR", lambda: self.display_seed_qr(True)),
                 ("SeedQR", self.display_seed_qr),
                 (t("Encrypted QR Code"), self.encrypt_qr_code),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()
@@ -77,7 +77,7 @@ class MnemonicsView(Page):
                 (t("Numbers"), self.display_mnemonic_numbers),
                 ("Stackbit 1248", self.stackbit),
                 ("Tiny Seed", self.tiny_seed),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()
@@ -149,7 +149,7 @@ class MnemonicsView(Page):
                         Utils.BASE_OCT_SUFFIX,
                     ),
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         submenu.run_loop()

--- a/src/krux/pages/home_pages/pub_key_view.py
+++ b/src/krux/pages/home_pages/pub_key_view.py
@@ -27,6 +27,7 @@ from .. import (
     Menu,
     MENU_CONTINUE,
     MENU_EXIT,
+    cta_back,
 )
 from ...sd_card import PUBKEY_FILE_EXTENSION
 from ...key import P2SH_P2WPKH, P2SH_P2WSH, P2WPKH, P2WSH
@@ -68,7 +69,7 @@ class PubkeyView(Page):
                         else lambda: _save_xpub_to_sd(version)
                     ),
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ]
             full_pub_key = self.ctx.wallet.key.account_pubkey_str(version)
             menu_offset = 5 + len(self.ctx.display.to_lines(full_pub_key))
@@ -116,7 +117,7 @@ class PubkeyView(Page):
             pub_key_menu_items.append(
                 (title + " - " + t("QR Code"), lambda ver=version: _pub_key_qr(ver))
             )
-        pub_key_menu_items.append(("< " + t("Back"), lambda: MENU_EXIT))
+        pub_key_menu_items.append(cta_back())
         pub_key_menu = Menu(self.ctx, pub_key_menu_items)
         while True:
             _, status = pub_key_menu.run_loop()

--- a/src/krux/pages/home_pages/pub_key_view.py
+++ b/src/krux/pages/home_pages/pub_key_view.py
@@ -68,7 +68,7 @@ class PubkeyView(Page):
                         else lambda: _save_xpub_to_sd(version)
                     ),
                 ),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ]
             full_pub_key = self.ctx.wallet.key.account_pubkey_str(version)
             menu_offset = 5 + len(self.ctx.display.to_lines(full_pub_key))
@@ -116,7 +116,7 @@ class PubkeyView(Page):
             pub_key_menu_items.append(
                 (title + " - " + t("QR Code"), lambda ver=version: _pub_key_qr(ver))
             )
-        pub_key_menu_items.append((t("Back"), lambda: MENU_EXIT))
+        pub_key_menu_items.append(("< " + t("Back"), lambda: MENU_EXIT))
         pub_key_menu = Menu(self.ctx, pub_key_menu_items)
         while True:
             _, status = pub_key_menu.run_loop()

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -199,7 +199,7 @@ class SignMessage(Utils):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                cta_back(None),
+                cta_back(lambda: None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -24,7 +24,7 @@ import gc
 from embit import bip32, compact
 import hashlib
 import binascii
-from .. import MENU_CONTINUE, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu
+from .. import MENU_CONTINUE, MENU_EXIT, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu
 from ...themes import theme
 from ...display import (
     DEFAULT_PADDING,
@@ -199,7 +199,7 @@ class SignMessage(Utils):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: None),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -24,7 +24,7 @@ import gc
 from embit import bip32, compact
 import hashlib
 import binascii
-from .. import MENU_CONTINUE, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu
+from .. import MENU_CONTINUE, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu, cta_back
 from ...themes import theme
 from ...display import (
     DEFAULT_PADDING,
@@ -199,7 +199,7 @@ class SignMessage(Utils):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: None),
+                cta_back(None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -24,7 +24,7 @@ import gc
 from embit import bip32, compact
 import hashlib
 import binascii
-from .. import MENU_CONTINUE, MENU_EXIT, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu
+from .. import MENU_CONTINUE, LOAD_FROM_CAMERA, LOAD_FROM_SD, Menu
 from ...themes import theme
 from ...display import (
     DEFAULT_PADDING,
@@ -199,7 +199,7 @@ class SignMessage(Utils):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -199,7 +199,7 @@ class SignMessage(Utils):
                     t("Sign to SD card"),
                     None if not self.has_sd_card() else lambda: None,
                 ),
-                (t("Back"), lambda: None),
+                ("< " + t("Back"), lambda: None),
             ],
         )
         index, _ = sign_menu.run_loop()

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -74,7 +74,7 @@ class Login(Page):
                 (t("Via Camera"), self.load_key_from_camera),
                 (t("Via Manual Input"), self.load_key_from_manual_input),
                 (t("From Storage"), self.load_mnemonic_from_storage),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()
@@ -92,7 +92,7 @@ class Login(Page):
                     "Tiny Seed",
                     self.load_key_from_tiny_seed_image,
                 ),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()
@@ -109,7 +109,7 @@ class Login(Page):
                 (t("Word Numbers"), self.pre_load_key_from_digits),
                 ("Tiny Seed (Bits)", self.load_key_from_tiny_seed),
                 ("Stackbit 1248", self.load_key_from_1248),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()
@@ -136,7 +136,7 @@ class Login(Page):
                 (t("Via Words"), lambda: self.load_key_from_text(new=True)),
                 (t("Via D6"), self.new_key_from_dice),
                 (t("Via D20"), lambda: self.new_key_from_dice(True)),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()
@@ -241,7 +241,7 @@ class Login(Page):
                     (t("Load Wallet"), lambda: None),
                     (t("Passphrase"), lambda: None),
                     (t("Customize"), lambda: None),
-                    (t("Back"), lambda: MENU_EXIT),
+                    ("< " + t("Back"), lambda: MENU_EXIT),
                 ],
                 offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
             )
@@ -548,7 +548,7 @@ class Login(Page):
                 (t("Decimal"), self.load_key_from_digits),
                 (t("Hexadecimal"), self.load_key_from_hexadecimal),
                 (t("Octal"), self.load_key_from_octal),
-                (t("Back"), lambda: MENU_EXIT),
+                ("< " + t("Back"), lambda: MENU_EXIT),
             ],
         )
         index, status = submenu.run_loop()

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -37,6 +37,7 @@ from . import (
     ESC_KEY,
     LETTERS,
     choose_len_mnemonic,
+    cta_back,
 )
 
 DIGITS = "0123456789"
@@ -74,7 +75,7 @@ class Login(Page):
                 (t("Via Camera"), self.load_key_from_camera),
                 (t("Via Manual Input"), self.load_key_from_manual_input),
                 (t("From Storage"), self.load_mnemonic_from_storage),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()
@@ -92,7 +93,7 @@ class Login(Page):
                     "Tiny Seed",
                     self.load_key_from_tiny_seed_image,
                 ),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()
@@ -109,7 +110,7 @@ class Login(Page):
                 (t("Word Numbers"), self.pre_load_key_from_digits),
                 ("Tiny Seed (Bits)", self.load_key_from_tiny_seed),
                 ("Stackbit 1248", self.load_key_from_1248),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()
@@ -136,7 +137,7 @@ class Login(Page):
                 (t("Via Words"), lambda: self.load_key_from_text(new=True)),
                 (t("Via D6"), self.new_key_from_dice),
                 (t("Via D20"), lambda: self.new_key_from_dice(True)),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()
@@ -241,7 +242,7 @@ class Login(Page):
                     (t("Load Wallet"), lambda: None),
                     (t("Passphrase"), lambda: None),
                     (t("Customize"), lambda: None),
-                    ("< " + t("Back"), lambda: MENU_EXIT),
+                    cta_back(),
                 ],
                 offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
             )
@@ -548,7 +549,7 @@ class Login(Page):
                 (t("Decimal"), self.load_key_from_digits),
                 (t("Hexadecimal"), self.load_key_from_hexadecimal),
                 (t("Octal"), self.load_key_from_octal),
-                ("< " + t("Back"), lambda: MENU_EXIT),
+                cta_back(),
             ],
         )
         index, status = submenu.run_loop()

--- a/src/krux/pages/qr_view.py
+++ b/src/krux/pages/qr_view.py
@@ -414,7 +414,7 @@ class SeedQRView(Page):
                     ),
                 )
             )
-        qr_menu.append((t("Back"), lambda: None))
+        qr_menu.append(("< " + t("Back"), lambda: MENU_EXIT))
         submenu = Menu(self.ctx, qr_menu, offset=2 * FONT_HEIGHT)
         submenu.run_loop()
         return MENU_CONTINUE

--- a/src/krux/pages/qr_view.py
+++ b/src/krux/pages/qr_view.py
@@ -487,11 +487,8 @@ class SeedQRView(Page):
                     ),
                 ),
                 (t("Print to QR"), printer_func),
-                cta_back(tlabel="Back to Menu"),
+                cta_back(label=t("Back to Menu")),
             ]
-            _ = t(
-                "Back to Menu"
-            )  # TODO: a better way to do this (food for i18n tooling)
             submenu = Menu(self.ctx, qr_menu)
             _, status = submenu.run_loop()
             if status == MENU_EXIT:

--- a/src/krux/pages/qr_view.py
+++ b/src/krux/pages/qr_view.py
@@ -22,7 +22,7 @@
 
 import qrcode
 from embit.wordlists.bip39 import WORDLIST
-from . import Page, Menu, MENU_CONTINUE, MENU_EXIT, ESC_KEY
+from . import Page, Menu, MENU_CONTINUE, MENU_EXIT, ESC_KEY, cta_back
 from ..themes import theme, WHITE, BLACK
 from ..krux_settings import t
 from ..qr import get_size
@@ -414,7 +414,7 @@ class SeedQRView(Page):
                     ),
                 )
             )
-        qr_menu.append(("< " + t("Back"), lambda: MENU_EXIT))
+        qr_menu.append(cta_back())
         submenu = Menu(self.ctx, qr_menu, offset=2 * FONT_HEIGHT)
         submenu.run_loop()
         return MENU_CONTINUE
@@ -487,8 +487,11 @@ class SeedQRView(Page):
                     ),
                 ),
                 (t("Print to QR"), printer_func),
-                (t("Back to Menu"), lambda: MENU_EXIT),
+                cta_back(tlabel="Back to Menu"),
             ]
+            _ = t(
+                "Back to Menu"
+            )  # TODO: a better way to do this (food for i18n tooling)
             submenu = Menu(self.ctx, qr_menu)
             _, status = submenu.run_loop()
             if status == MENU_EXIT:

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -234,9 +234,7 @@ class SettingsPage(Page):
             # Case for "Back" on the main Settings
             if settings_namespace.namespace == Settings.namespace:
                 items.append((t("Factory Settings"), self.restore_settings))
-                # TODO: solve below so tests don't fail "assert_has_calls" checks
-                # items.append(cta_back(self._settings_exit_check))
-                items.append(("< " + t("Back"), self._settings_exit_check))
+                items.append(cta_back(self._settings_exit_check))
             else:
                 items.append(cta_back())
 

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -233,9 +233,9 @@ class SettingsPage(Page):
             # Case for "Back" on the main Settings
             if settings_namespace.namespace == Settings.namespace:
                 items.append((t("Factory Settings"), self.restore_settings))
-                items.append((t("Back"), self._settings_exit_check))
+                items.append(("< " + t("Back"), self._settings_exit_check))
             else:
-                items.append((t("Back"), lambda: MENU_EXIT))
+                items.append(("< " + t("Back"), lambda: MENU_EXIT))
 
             submenu = Menu(self.ctx, items)
             index, status = submenu.run_loop()

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -51,6 +51,7 @@ from . import (
     MENU_EXIT,
     ESC_KEY,
     DEFAULT_PADDING,
+    cta_back,
 )
 import os
 
@@ -233,9 +234,11 @@ class SettingsPage(Page):
             # Case for "Back" on the main Settings
             if settings_namespace.namespace == Settings.namespace:
                 items.append((t("Factory Settings"), self.restore_settings))
+                # TODO: solve below so tests don't fail "assert_has_calls" checks
+                # items.append(cta_back(self._settings_exit_check))
                 items.append(("< " + t("Back"), self._settings_exit_check))
             else:
-                items.append(("< " + t("Back"), lambda: MENU_EXIT))
+                items.append(cta_back())
 
             submenu = Menu(self.ctx, items)
             index, status = submenu.run_loop()

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -55,7 +55,7 @@ class Tools(Page):
                     (t("Descriptor Addresses"), self.descriptor_addresses),
                     (t("Remove Mnemonic"), self.rm_stored_mnemonic),
                     (t("Wipe Device"), self.wipe_device),
-                    (t("Back"), lambda: MENU_EXIT),
+                    ("< " + t("Back"), lambda: MENU_EXIT),
                 ],
             ),
         )

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -29,12 +29,12 @@ from . import (
     Page,
     Menu,
     MENU_CONTINUE,
-    MENU_EXIT,
     ESC_KEY,
     LETTERS,
     UPPERCASE_LETTERS,
     NUM_SPECIAL_1,
     NUM_SPECIAL_2,
+    cta_back,
 )
 from .file_manager import SD_ROOT_PATH
 from ..format import generate_thousands_separator
@@ -55,7 +55,7 @@ class Tools(Page):
                     (t("Descriptor Addresses"), self.descriptor_addresses),
                     (t("Remove Mnemonic"), self.rm_stored_mnemonic),
                     (t("Wipe Device"), self.wipe_device),
-                    ("< " + t("Back"), lambda: MENU_EXIT),
+                    cta_back(),
                 ],
             ),
         )

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -34,6 +34,7 @@ from . import (
     UPPERCASE_LETTERS,
     NUM_SPECIAL_1,
     NUM_SPECIAL_2,
+    cta_back,
 )
 from .settings_page import DIGITS
 from ..key import SINGLESIG_SCRIPT_PURPOSE, MULTISIG_SCRIPT_PURPOSE
@@ -62,7 +63,7 @@ class PassphraseEditor(Page):
                 [
                     (t("Type BIP39 Passphrase"), self._load_passphrase),
                     (t("Scan BIP39 Passphrase"), self._load_qr_passphrase),
-                    ("< " + t("Back"), lambda: MENU_EXIT),
+                    cta_back(),
                 ],
                 disable_statusbar=True,
             )
@@ -134,7 +135,7 @@ class WalletSettings(Page):
                     ("Single/Multisig", lambda: None),
                     (t("Script Type"), (lambda: None) if not multisig else None),
                     (t("Account"), lambda: None),
-                    ("< " + t("Back"), lambda: MENU_EXIT),
+                    cta_back(),
                 ],
                 offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
             )

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -62,7 +62,7 @@ class PassphraseEditor(Page):
                 [
                     (t("Type BIP39 Passphrase"), self._load_passphrase),
                     (t("Scan BIP39 Passphrase"), self._load_qr_passphrase),
-                    (t("Back"), lambda: MENU_EXIT),
+                    ("< " + t("Back"), lambda: MENU_EXIT),
                 ],
                 disable_statusbar=True,
             )
@@ -134,7 +134,7 @@ class WalletSettings(Page):
                     ("Single/Multisig", lambda: None),
                     (t("Script Type"), (lambda: None) if not multisig else None),
                     (t("Account"), lambda: None),
-                    (t("Back"), lambda: MENU_EXIT),
+                    ("< " + t("Back"), lambda: MENU_EXIT),
                 ],
                 offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
             )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Perhaps with another "arrow" glyph, this will look nicer, but "< Back" is still very identifiable as a special menu item.

Also changed some tuples' 2nd item to the more standard "lambda: MENU_EXIT" instead of "lambda: None"

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
