### PR TITLE
Descriptor urtype account

### DIFF
--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -207,6 +207,15 @@ def parse_wallet(wallet_data, allow_assumption=None):
         except:
             pass
 
+        # Try to parse as a Crypto-Account type
+        try:
+            account = urtypes.crypto.Account.from_cbor(
+                wallet_data.cbor
+            ).output_descriptors[0]
+            return Descriptor.from_string(account.descriptor()), None
+        except:
+            pass
+
         # Treat the UR as a generic UR bytes object and extract the data for further processing
         wallet_data = urtypes.Bytes.from_cbor(wallet_data.cbor).data
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I'm not sure if this belongs, but I found this while trying to scan an xpub exported by seedsigner for sparrow, while testing/inspecting the seedsigner release candidate for v0.8.0.

Conveniently, all 4 of the coordinators supported by both seedsigner/krux deal well with the xpubs exported for sparrow by seedsigner, and they're often scanned with better success, especially with a bad webcam, than the xpubs exported specifically for that coordinator.  (For singlesig types, they're full descriptors with script wrapper and checksum, always with the mainnet "xpub" version bytes).  In coordinators that support testnet mode... they force the keys to testnet and the resulting import is a "tpub" (this is not the case for krux, because krux respects the xpub exactly in watch-only mode, and would show a key mismatch if a wallet were loaded for testnet).

My reasoning for this code, is simply to verify between my only two signers... but it's more realistic that bitcoiners will be verifying descriptors from their coordinator (which works flawlessly whether setup by krux or seedsigner)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
