### PR TITLE
Docs: returning missing link for info about microSD card

### DIFF
--- a/docs/snippets/sd-card-info-faq.en.txt
+++ b/docs/snippets/sd-card-info-faq.en.txt
@@ -1,1 +1,1 @@
-We cannot guarantee that a microSD card is compatible and will work in your device; you'll need to test it on the device to be sure, read the [FAQ](/krux/faq/#why-isnt-krux-detecting-my-microsd-card-or-presenting-an-error) for more info.
+We cannot guarantee that a microSD card is compatible and will work in your device; you'll need to test it on the device to be sure, read the [Troubleshooting](troubleshooting.md/#why-isnt-krux-detecting-my-microsd-card-or-presenting-an-error) for more info.

--- a/docs/troubleshooting.en.md
+++ b/docs/troubleshooting.en.md
@@ -145,3 +145,7 @@ For now, a workaround you can do is to take a picture or video of the QR code wi
 ### Why Does Krux Say the Entropy of My Fifty Dice Rolls Does Not Contain 128 Bits of Entropy?
 
 Please check how [entropy measurement](getting-started/features/entropy.md) works.
+
+### Why isn't Krux detecting my microSD card or presenting an error?
+Starting from version 23.09.0, Krux supports SD card hot plugging. If you are using older versions, it may only detect the SD card at boot, so make sure Krux is turned off when inserting the microSD into it. To test the card compatibility use Krux [Tools>Check SD Card](getting-started/features/tools.md/#check-sd-card).
+Make sure the SD card is using MBR/DOS partition table and FAT32 format.


### PR DESCRIPTION
Returning missing link for info about microSD card

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other
