### PR TITLE
Uses grid_type to label TinySeed page ui

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -88,7 +88,7 @@ class Login(Page):
             self.ctx,
             [
                 (t("QR Code"), self.load_key_from_qr_code),
-                ("Tiny Seed", lambda: self.load_key_from_tiny_seed_image("TinySeed")),
+                ("Tiny Seed", lambda: self.load_key_from_tiny_seed_image("Tiny Seed")),
                 (
                     "OneKey KeyTag",
                     lambda: self.load_key_from_tiny_seed_image("OneKey KeyTag"),
@@ -681,7 +681,7 @@ class Login(Page):
             return self._load_key_from_words(words)
         return MENU_CONTINUE
 
-    def load_key_from_tiny_seed_image(self, grid_type="TinySeed"):
+    def load_key_from_tiny_seed_image(self, grid_type="Tiny Seed"):
         """Menu handler to scan key from Tiny Seed sheet metal storage method"""
         from .tiny_seed import TinyScanner
 

--- a/src/krux/pages/tiny_seed.py
+++ b/src/krux/pages/tiny_seed.py
@@ -56,7 +56,7 @@ TS_GO_POSITION = 167
 class TinySeed(Page):
     """Class for handling Tinyseed fomat"""
 
-    def __init__(self, ctx):
+    def __init__(self, ctx, label=None):
         super().__init__(ctx, None)
         self.ctx = ctx
         self.x_offset = MINIMAL_PADDING + 2 * FONT_WIDTH
@@ -71,6 +71,10 @@ class TinySeed(Page):
             self.y_offset = DEFAULT_PADDING + 3 * FONT_HEIGHT
         else:
             self.y_offset = 2 * FONT_HEIGHT
+        if label == "Binary Grid":
+            self.label = t("Binary Grid")
+        else:
+            self.label = label
 
     def _draw_grid(self):
         """Draws grid for import and export Tinyseed UI"""
@@ -96,7 +100,7 @@ class TinySeed(Page):
 
     def _draw_labels(self, page):
         """Draws labels for import and export Tinyseed UI"""
-        self.ctx.display.draw_hcentered_text("Tiny Seed")
+        self.ctx.display.draw_hcentered_text(self.label)
 
         # case for non m5stickv, cube
         if not MINIMAL_DISPLAY:
@@ -582,7 +586,7 @@ class TinyScanner(Page):
 
     # Settings for different binary grid types
     binary_grid_settings = {
-        "TinySeed": {
+        "Tiny Seed": {
             "xpad_factor": (240 / (12 * 345)),
             "ypad_factor": (210 / (12 * 272)),
             "x_offset_factor_amigo_p0": 39 / 345,
@@ -628,7 +632,7 @@ class TinyScanner(Page):
 
     grid_settings = None
 
-    def __init__(self, ctx, grid_type="TinySeed"):
+    def __init__(self, ctx, grid_type="Tiny Seed"):
         super().__init__(ctx, None)
         self.ctx = ctx
         # Capturing flag used for first page of 24 words seed
@@ -638,7 +642,7 @@ class TinyScanner(Page):
         self.y_regions = []
         self.time_frame = time.ticks_ms()
         self.previous_seed_numbers = [1] * 12
-        self.tiny_seed = TinySeed(self.ctx)
+        self.tiny_seed = TinySeed(self.ctx, label=grid_type)
         self.grid_settings = self.binary_grid_settings[grid_type]
 
     def _map_punches_region(self, rect_size, page=0):


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With my jaw-on-the-floor, while reviewing @3rdIteration's TinySeed improvements to support OneKey-KeyTag and Binary-grid formats, I noticed that once a grid is scanned and user has a chance to edit, that "Tiny Seed" as the title of the page might be confusing (even though krux is not confused about which grid_format to use).

This pr alters TinyScanner's binary_grid_settings for the default key from "TinySeed" to "Tiny Seed" and then passes the grid_type into TinySeed page so that ui/ux labelling can be appropriate for the current mode when editing.  note: Only the "Binary Grid" key is localized, while the other two keys retain their trademark english names.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
