### PR TITLE
adjusted test to cover bugfix in commit 3eba4e4

### DIFF
--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -244,7 +244,10 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
     mocker.patch.object(
         message_signer,
         "capture_qr_code",
-        new=lambda: ("signmessage m/84h/1h/0h/0/3 ascii:a test message", FORMAT_NONE),
+        new=lambda: (
+            "signmessage m/84h/1h/0h/0/3 ascii:a test message with a colon ':' character.",
+            FORMAT_NONE,
+        ),
     )
     message_signer.sign_message()
 
@@ -252,7 +255,11 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
         [mocker.call("Message:", 10, theme.highlight_color)]
     )
     ctx.display.draw_hcentered_text.assert_has_calls(
-        [mocker.call("a test message", mocker.ANY, max_lines=10)]
+        [
+            mocker.call(
+                "a test message with a colon ':' character.", mocker.ANY, max_lines=10
+            )
+        ]
     )
     ctx.display.draw_hcentered_text.assert_has_calls(
         [mocker.call("Address:", mocker.ANY, theme.highlight_color)]
@@ -261,7 +268,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
         [mocker.call("3. bc1qgl..cn3", mocker.ANY)],
     )
     message_signer.display_qr_codes.assert_called_once_with(
-        "HzRkfdy2sqvszgCn1jLkq3KfqP6Zd1wwG0v+95zfIz0WNizoXjjFBmB7ZxOHXSj4qAhwoNgUPJHDqzFaOq30URA=",
+        "IHx1+DGW83eZZpV8rOT/9l/yUYa2ncmCr/Mnq7XBJmmyFCUWKceHZQqUZAk60XuwlBox3d3hAa4FU59AXOjbALo=",
         0,
         "Signed Message",
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Prior to commit 3eba4e4 and related to signing messages, if a message contained a ":" colon character, it was converted to a " " space character.  This pr adjusts the existing unit-test so that it would fail with prior versions and succeeds with 3eba4e4's fix.

User's who need to sign on a message using a previous release of krux might note the conversion of ":" to " ", which is visible in-device while signing. (ie: In Sparrow's "Sign/Verify Message" screen, they'd convert any ":" characters in the "message" text-area to " "... and then the krux signature would verify as valid) 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other: Adjusted unit test
