### PR TITLE
embit remove unused  py_ripemd160.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,7 @@ RUN rm -rf vendor/embit/src/embit/util/prebuilt && \
     rm -f vendor/embit/src/embit/wordlists/slip39.py && \
     rm -f vendor/embit/src/embit/util/ctypes_secp256k1.py && \
     rm -f vendor/embit/src/embit/util/py_secp256k1.py && \
+    rm -f vendor/embit/src/embit/util/py_ripemd160.py && \
     find vendor/embit -type d -name '__pycache__' -exec rm -rv {} + -depth
 
 # copy firmware to WORKDIR (src)


### PR DESCRIPTION
removing from Docker as it is used only in Python, micropython uses `ripemd160` from `hashlib`. Also `ripemd160` is only used in embit for miniscript.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
