### PR TITLE
draw_ram_indicator() easier numbers to read, includes RAM just collected

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -639,9 +639,36 @@ class Menu:
     #     self.draw_ram_indicator()
 
     # def draw_ram_indicator(self):
-    #     """Draws the amount of free RAM in the status bar"""
+    #     """Draws the amount of free RAM in the status bar +recently-collected"""
+    #     def strnum(_in):
+    #         large_units = ("","K","M")
+
+    #         value = _in
+    #         for i in range(len(large_units)):
+    #             unit = large_units[i]
+    #             if value < 2**10:
+    #                 break
+    #             if i+1 < len(large_units):
+    #                 value /= 2**10
+
+    #         if value == int(value):
+    #             fmt = "%d" + unit
+    #         else:
+    #            if value < 1:
+    #                fmt = "%0.3f" + unit
+    #            elif value < 10:
+    #                fmt = "%.2f" + unit
+    #            elif value < 100:
+    #                fmt = "%.1f" + unit
+    #            else:
+    #                fmt = "%d" + unit
+
+    #         return fmt % value
+
+    #     pre_collect = gc.mem_free()
     #     gc.collect()
-    #     ram_text = "RAM: " + str(gc.mem_free())
+    #     post_collect = gc.mem_free()
+    #     ram_text = "RAM: " + strnum(post_collect) + " +" + strnum(post_collect - pre_collect)
     #     self.ctx.display.draw_string(12, 0, ram_text, GREEN)
 
     def draw_battery_indicator(self):


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The idea here was twofold:
* easier free RAM numbers to read (between 1 and 1023) usually 3 digits of precision with K or M to see the big picture,
* remember amount of free RAM before gc.collect() frees it so that we can see how much was recently collected... but this will not always be true if there is a habit of using gc.collect() within routines that are memory-costly.

Since there will be loops that absolutely require gc.collect(), perhaps we can make a habit of doing it like:
```python
pre_collect = gc.mem_free()
gc.collect()
print("%s has collected %d bytes" % (__name__, gc.mem_free() - pre_collect))
```
...so that we can at least see how much memory had been used and that gc.collect() freed it for x times for this routine?  Otherwise, a bad habit of collecting memory even when it's not necessary may become the norm?

Alternately, I wonder if we might never gc.collect() except where we are absolutely sure it's necessary... and then more generally use try/except "MemoryError", then do gc.collect() within the except block, and continuing on?

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->
Debugging RAM usage.

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other
