### PR TITLE
fix MaixPy submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = ../../selfcustody/Kboot
 [submodule "firmware/MaixPy"]
 	path = firmware/MaixPy
-	url = ../MaixPy
+	url = ../../selfcustody/MaixPy


### PR DESCRIPTION
### What is this PR for?
When starting to work with this project I created a fork of the selfcustody/krux repo and then tried to clone it with `git clone --recurse-submodules`. This caused an error with MaixPy because it was looking for my fork of MaixPy which did not exist. See error: 
```
remote: Repository not found.
fatal: Authentication failed for 'https://github.com/luke21m/MaixPy/'
fatal: clone of 'https://github.com/luke21m/MaixPy' into submodule path '/Users/luke/krux/firmware/MaixPy' failed
Failed to clone 'firmware/MaixPy' a second time, aborting
```
Since the other submodules were cloning without me having to manually fork them on github, I changed the MaixPy url in `.gitmodules` to match. Then it works. 

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
