### PR TITLE
Avoid exiting when user misclick and cancel the load of a file

### DIFF
--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -26,6 +26,7 @@ from . import Page, Menu, MENU_EXIT, MENU_CONTINUE
 from ..sd_card import SDHandler
 from ..krux_settings import t
 from ..format import generate_thousands_separator, render_decimal_separator
+from ..display import BOTTOM_PROMPT_LINE
 
 LIST_FILE_DIGITS = 9  # len on large devices per menu item
 LIST_FILE_DIGITS_SMALL = 5  # len on small devices per menu item
@@ -147,6 +148,17 @@ class FileManager(Page):
 
         self.display_file(file)
         self.ctx.input.wait_for_button()
+        return MENU_CONTINUE
+
+    def load_file(self, file):
+        """Handler to ask if will load selected file in the file explorer"""
+        if SDHandler.dir_exists(file):
+            return MENU_EXIT
+
+        self.display_file(file)
+
+        if self.prompt(t("Load?"), BOTTOM_PROMPT_LINE):
+            return MENU_EXIT
         return MENU_CONTINUE
 
     def display_file(self, file):

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -211,6 +211,8 @@ class SignMessage(Utils):
         """Message signed at a derived Bitcoin address - SD card"""
         data = data.decode() if isinstance(data, bytes) else data
         lines = [line.strip() for line in data.splitlines() if line.strip()]
+        if len(lines) == 0:
+            return None
         script_type = lines[-1].lower()
         if len(lines) < 2 or script_type not in SINGLESIG_SCRIPT_PURPOSE:
             return None

--- a/src/krux/pages/utils.py
+++ b/src/krux/pages/utils.py
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 
 from . import Page
-from ..display import BOTTOM_PROMPT_LINE
 from ..krux_settings import t
 from ..sd_card import SDHandler
 from embit.wordlists.bip39 import WORDLIST
@@ -61,15 +60,16 @@ class Utils(Page):
                     from .file_manager import FileManager
 
                     file_manager = FileManager(self.ctx)
-                    filename = file_manager.select_file(file_extension=file_ext)
+                    filename = file_manager.select_file(
+                        select_file_handler=file_manager.load_file,
+                        file_extension=file_ext,
+                    )
 
                     if filename:
-                        filename = file_manager.display_file(filename)
-
-                        if self.prompt(t("Load?"), BOTTOM_PROMPT_LINE):
-                            if only_get_filename:
-                                return filename, None
-                            return filename, sd.read_binary(filename)
+                        filename = filename[4:]  # remove "/sd/" prefix
+                        if only_get_filename:
+                            return filename, None
+                        return filename, sd.read_binary(filename)
         return "", None
 
     @staticmethod

--- a/tests/pages/test_utils.py
+++ b/tests/pages/test_utils.py
@@ -4,7 +4,7 @@ from .test_tools import mock_file_operations, SEEDS_JSON
 
 def test_load_file(m5stickv, mocker, mock_file_operations):
     from krux.pages.utils import Utils
-    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.input import BUTTON_ENTER
 
     BTN_SEQUENCE = [
         BUTTON_ENTER,  # Pick first file
@@ -14,7 +14,7 @@ def test_load_file(m5stickv, mocker, mock_file_operations):
     for only_get_filename in ONLY_GET_FILENAME_OPTIONS:
         mocker.patch(
             "krux.sd_card.SDHandler.dir_exists",
-            mocker.MagicMock(side_effect=[True, False]),
+            mocker.MagicMock(side_effect=[True, False, False]),
         )
         ctx = create_ctx(mocker, BTN_SEQUENCE)
         utils = Utils(ctx)
@@ -32,7 +32,6 @@ def test_load_file(m5stickv, mocker, mock_file_operations):
 
 def test_load_file_with_no_sd(m5stickv, mocker):
     from krux.pages.utils import Utils
-    from krux.input import BUTTON_PAGE
 
     mocker.patch(
         "krux.sd_card.SDHandler.dir_exists",


### PR DESCRIPTION
### What is this PR for?
- Fixed bug when signing message with empty file
- Avoid exiting when user misclick and cancel the load of a file

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
