### PR TITLE
Simplified select_file_handler responsibilities in FileManager.select_file()

### DIFF
--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -112,8 +112,14 @@ class FileManager(Page):
                         menu_items.append(
                             (
                                 display_filename,
-                                lambda file=filename: select_file_handler(
-                                    path + "/" + file
+                                (
+                                    (lambda: MENU_EXIT)
+                                    if is_directory
+                                    else (
+                                        lambda file=filename: select_file_handler(
+                                            path + "/" + file
+                                        )
+                                    )
                                 ),
                             )
                         )
@@ -143,8 +149,6 @@ class FileManager(Page):
 
     def show_file_details(self, file):
         """Handler to print file info when selecting a file in the file explorer"""
-        if SDHandler.dir_exists(file):
-            return MENU_EXIT
 
         self.display_file(file)
         self.ctx.input.wait_for_button()
@@ -152,11 +156,8 @@ class FileManager(Page):
 
     def load_file(self, file):
         """Handler to ask if will load selected file in the file explorer"""
-        if SDHandler.dir_exists(file):
-            return MENU_EXIT
 
         self.display_file(file)
-
         if self.prompt(t("Load?"), BOTTOM_PROMPT_LINE):
             return MENU_EXIT
         return MENU_CONTINUE

--- a/tests/pages/test_file_manager.py
+++ b/tests/pages/test_file_manager.py
@@ -42,7 +42,7 @@ def test_file_exploring(m5stickv, mocker, mock_file_operations):
 
     # to view this directory, selected file isn't a directory
     mocker.patch(
-        "krux.sd_card.SDHandler.dir_exists", mocker.MagicMock(side_effect=[True, False])
+        "krux.sd_card.SDHandler.dir_exists", mocker.MagicMock(side_effect=[True])
     )
     # first 2 entries are files, next 2 are directories
     mocker.patch(
@@ -101,9 +101,9 @@ def test_file_load(m5stickv, mocker, mock_file_operations):
     # to view this directory, selected file isn't a directory
     mocker.patch(
         "krux.sd_card.SDHandler.dir_exists",
-        mocker.MagicMock(side_effect=[True, False, False]),
+        mocker.MagicMock(side_effect=[True, False]),
     )
-    # first 2 entries are files, next 2 are directories
+    # first 3 entries are files, next 2 are directories
     mocker.patch(
         "krux.sd_card.SDHandler.file_exists",
         mocker.MagicMock(side_effect=[True, True, True, False, False]),
@@ -165,12 +165,13 @@ def test_file_load_cancel(m5stickv, mocker, mock_file_operations):
     # to view this directory, selected file isn't a directory
     mocker.patch(
         "krux.sd_card.SDHandler.dir_exists",
-        mocker.MagicMock(side_effect=[True, False, False, False]),
+        mocker.MagicMock(side_effect=[True, False]),
     )
-    # first 2 entries are files, next 2 are directories
+    # first 3 entries are files, next 2 are directories
+    _listing_returns = [True, True, True, False, False]
     mocker.patch(
         "krux.sd_card.SDHandler.file_exists",
-        mocker.MagicMock(side_effect=[True, True, True, False, False]),
+        mocker.MagicMock(side_effect=_listing_returns),
     )
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     file_manager = FileManager(ctx)

--- a/tests/pages/test_utils.py
+++ b/tests/pages/test_utils.py
@@ -14,7 +14,11 @@ def test_load_file(m5stickv, mocker, mock_file_operations):
     for only_get_filename in ONLY_GET_FILENAME_OPTIONS:
         mocker.patch(
             "krux.sd_card.SDHandler.dir_exists",
-            mocker.MagicMock(side_effect=[True, False, False]),
+            mocker.MagicMock(side_effect=[True, False]),
+        )
+        mocker.patch(
+            "krux.sd_card.SDHandler.file_exists",
+            mocker.MagicMock(side_effect=[True, True]),
         )
         ctx = create_ctx(mocker, BTN_SEQUENCE)
         utils = Utils(ctx)


### PR DESCRIPTION
### What is this PR for?
- select_file_handler arg simplified to handle only files NOT dir

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
