### PR TITLE
Fix btn yahboom not working

### DIFF
--- a/simulator/kruxsim/mocks/sensor.py
+++ b/simulator/kruxsim/mocks/sensor.py
@@ -88,7 +88,8 @@ def run(on):
     if on:
         capturer = VideoCapture(0)
     else:
-        capturer.release()
+        if capturer:
+            capturer.release()
 
 
 def find_qrcodes(img):

--- a/src/boot.py
+++ b/src/boot.py
@@ -26,9 +26,6 @@ import time
 import gc
 import os
 
-sys.path.append("")
-sys.path.append(".")
-
 from krux.power import power_manager
 
 MIN_SPLASH_WAIT_TIME = 1000

--- a/src/krux/input.py
+++ b/src/krux/input.py
@@ -250,6 +250,7 @@ class Input:
             or self.touch_value() == PRESSED
         ):
             time.sleep_ms(BUTTON_WAIT_PRESS_DELAY)
+            self.reset_ios_state()
             self.wdt_feed_inc_entropy()
 
     def _detect_press_type(self, btn):


### PR DESCRIPTION
### What is this PR for?
Fix Yahboom v1.1 btn not working after this change: https://github.com/selfcustody/krux/commit/093285a58752bec0f53b385f4ee64c676115657b#diff-ce5d263efd2e8bec3590c6bd71cdcb3838a0eac2b949ed6abfa3e4f2210ddb17L252

Also:
- removed unnecessary code at `boot.py`
- fixed error msg appearing on simulator `Camera not found: 'NoneType' object has no attribute 'release'`

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
