### PR TITLE
Hide mnemonic when wallet loading if the Hide mnemonic setting is True

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -254,8 +254,10 @@ class Login(Page):
 
         from .mnemonic_editor import MnemonicEditor
 
-        mnemonic_editor = MnemonicEditor(self.ctx, mnemonic, new)
-        mnemonic = mnemonic_editor.edit()
+        # If the mnemonic is not hidden, show the mnemonic editor
+        if not Settings().security.hide_mnemonic:
+            mnemonic_editor = MnemonicEditor(self.ctx, mnemonic, new)
+            mnemonic = mnemonic_editor.edit()
         if mnemonic is None:
             return MENU_CONTINUE
         self.ctx.display.clear()


### PR DESCRIPTION
### What is this PR for?
When `Hide mnemonic` setting is True, it will hide the mnemonic while login

### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
