### PR TITLE
Keeps the ABC key in the same position for all keypad types

### DIFF
--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -69,13 +69,13 @@ class Keypad:
     def more_index(self):
         """Returns the index of the "More" key"""
         if len(self.keysets) > 1:
-            return self.del_index - 1
+            return self.go_index + 1
         return None
 
     @property
     def del_index(self):
         """Returns the index of the "Del" key"""
-        return len(self.keys) + self.empty_keys + (1 if len(self.keysets) > 1 else 0)
+        return len(self.keys) + self.empty_keys
 
     @property
     def esc_index(self):

--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -69,13 +69,13 @@ class Keypad:
     def more_index(self):
         """Returns the index of the "More" key"""
         if len(self.keysets) > 1:
-            return self.go_index + 1
+            return self.del_index - 1
         return None
 
     @property
     def del_index(self):
         """Returns the index of the "Del" key"""
-        return len(self.keys) + self.empty_keys
+        return len(self.keys) + self.empty_keys + (1 if len(self.keysets) > 1 else 0)
 
     @property
     def esc_index(self):

--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -47,6 +47,8 @@ class Keypad:
         self.ctx = ctx
         self.keysets = keysets
         self.keyset_index = 0
+        self.max_keys_count = max([len(keyset) for keyset in keysets])
+        self.max_keys_count += FIXED_KEYS + (1 if len(keysets) > 1 else 0)
         self.key_h_spacing, self.key_v_spacing = self.map_keys_array(
             self.width, self.height
         )
@@ -90,12 +92,12 @@ class Keypad:
     @property
     def width(self):
         """Returns the needed width for the current keyset"""
-        return math.floor(math.sqrt(self.total_keys))
+        return math.floor(math.sqrt(self.max_keys_count))
 
     @property
     def height(self):
         """Returns the needed height for the current keyset"""
-        return math.ceil((self.total_keys) / self.width)
+        return math.ceil((self.max_keys_count) / self.width)
 
     @property
     def max_index(self):


### PR DESCRIPTION
This is a fix for one of my main frustrations when entering my passphrase - the moving "ABC" key!
As I looped through the keypads, the ABC key changed position on the numeric keypad and made me hit the delete key, meaning I had to loop through even more!

I have fixed this issue by changing the order of the keys so that the ABC key is in the bottom right of the screen for all keypad types in screens that use it. 

<img src="https://github.com/user-attachments/assets/5c03a133-8fde-4426-8699-ce13b23c9374" width="300" />
<img src="https://github.com/user-attachments/assets/544e3e48-ab91-4d54-99bd-abde093e3e84" width="300" />
<img src="https://github.com/user-attachments/assets/5b9e17c7-1ae4-49d3-8167-6741b7daafdb" width="300" />
<img src="https://github.com/user-attachments/assets/ae9ef66d-3493-4e46-810c-d6a7ec89bdce" width="300" />