### PR TITLE
Removed the unnecessary NUM_SPECIAL_3 

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -66,7 +66,6 @@ LETTERS = "abcdefghijklmnopqrstuvwxyz"
 UPPERCASE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 NUM_SPECIAL_1 = "1234567890 !#$%&'()*"
 NUM_SPECIAL_2 = '+,-./:;<=>?@[\\]^_"{|}~'
-NUM_SPECIAL_3 = " !#$%&'()*"  # NUM_SPECIAL_1 without numbers
 DIGITS = "1234567890"
 
 BATTERY_WIDTH = 22

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -51,8 +51,8 @@ from . import (
     DIGITS,
     LETTERS,
     UPPERCASE_LETTERS,
+    NUM_SPECIAL_1,
     NUM_SPECIAL_2,
-    NUM_SPECIAL_3,
     MENU_CONTINUE,
     MENU_EXIT,
     ESC_KEY,
@@ -159,14 +159,14 @@ class SettingsPage(Page):
         while len(tamper_check_code) < 6:
             tamper_check_code = self.capture_from_keypad(
                 t("Tamper Check Code"),
-                [DIGITS, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2, NUM_SPECIAL_3],
+                [NUM_SPECIAL_1, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2],
             )
             if tamper_check_code == ESC_KEY:
                 return MENU_CONTINUE
         while len(tc_code_confirm) < 6:
             tc_code_confirm = self.capture_from_keypad(
                 t("Confirm Tamper Check Code"),
-                [DIGITS, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2, NUM_SPECIAL_3],
+                [NUM_SPECIAL_1, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2],
             )
             if tc_code_confirm == ESC_KEY:
                 return MENU_CONTINUE

--- a/src/krux/pages/tc_code_verification.py
+++ b/src/krux/pages/tc_code_verification.py
@@ -23,11 +23,10 @@
 from . import (
     Page,
     ESC_KEY,
-    DIGITS,
     LETTERS,
     UPPERCASE_LETTERS,
+    NUM_SPECIAL_1,
     NUM_SPECIAL_2,
-    NUM_SPECIAL_3,
 )
 from ..krux_settings import t, TC_CODE_PATH, TC_CODE_PBKDF2_ITERATIONS
 
@@ -50,7 +49,7 @@ class TCCodeVerification(Page):
             else t("Tamper Check Code")
         )
         tc_code = self.capture_from_keypad(
-            label, [DIGITS, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2, NUM_SPECIAL_3]
+            label, [NUM_SPECIAL_1, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2]
         )
         if tc_code == ESC_KEY:
             return False

--- a/tests/pages/test_tc_code_verification.py
+++ b/tests/pages/test_tc_code_verification.py
@@ -6,8 +6,8 @@ def test_tc_code_verification(amigo, mocker):
         DIGITS,
         LETTERS,
         UPPERCASE_LETTERS,
+        NUM_SPECIAL_1,
         NUM_SPECIAL_2,
-        NUM_SPECIAL_3,
     )
     from krux.pages.tc_code_verification import TCCodeVerification
 
@@ -71,5 +71,5 @@ def test_tc_code_verification(amigo, mocker):
         keypad_label = "Current Tamper Check Code" if case[3] else "Tamper Check Code"
         tc_verifier.capture_from_keypad.assert_called_once_with(
             keypad_label,
-            [DIGITS, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2, NUM_SPECIAL_3],
+            [NUM_SPECIAL_1, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2],
         )


### PR DESCRIPTION
As multiple keyboards are now fixed in size it doesn't make sense to separate numbers from special chars for TC code anymore

### What is this PR for?


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
