### PR TITLE
Fix rare error when loading mnemonic word numbers

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -632,9 +632,10 @@ class Login(Page):
             return None
 
         def to_word(user_input):
-            word_num = int(user_input, 8)
-            if 0 < word_num <= 2048:
-                return WORDLIST[word_num - 1]
+            if user_input:
+                word_num = int(user_input, 8)
+                if 0 < word_num <= 2048:
+                    return WORDLIST[word_num - 1]
             return ""
 
         def possible_letters(prefix):
@@ -665,9 +666,10 @@ class Login(Page):
             return None
 
         def to_word(user_input):
-            word_num = int(user_input, 16)
-            if 0 < word_num <= 2048:
-                return WORDLIST[word_num - 1]
+            if user_input:
+                word_num = int(user_input, 16)
+                if 0 < word_num <= 2048:
+                    return WORDLIST[word_num - 1]
             return ""
 
         def possible_letters(prefix):
@@ -695,9 +697,10 @@ class Login(Page):
             return None
 
         def to_word(user_input):
-            word_num = int(user_input)
-            if 0 < word_num <= 2048:
-                return WORDLIST[word_num - 1]
+            if user_input:
+                word_num = int(user_input)
+                if 0 < word_num <= 2048:
+                    return WORDLIST[word_num - 1]
             return ""
 
         def possible_letters(prefix):

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -733,8 +733,8 @@ def test_load_key_from_digits(m5stickv, mocker, mocker_printer):
     cases = [
         (
             [BUTTON_ENTER]  # 1 press confirm msg
-            + [BUTTON_PAGE_PREV] # place on btn Go
-            + [BUTTON_ENTER] # press Go without any value should not present any error
+            + [BUTTON_PAGE_PREV]  # place on btn Go
+            + [BUTTON_ENTER]  # press Go without any value should not present any error
             + (
                 # 1 press change to number "2" and 1 press to select
                 [BUTTON_PAGE, BUTTON_ENTER]
@@ -828,8 +828,8 @@ def test_load_12w_from_hexadecimal(m5stickv, mocker, mocker_printer):
 
     BTN_SEQUENCE = (
         [BUTTON_ENTER]  # 1 press confirm msg
-        + [BUTTON_PAGE_PREV] # place on btn Go
-        + [BUTTON_ENTER] # press Go without any value should not present any error
+        + [BUTTON_PAGE_PREV]  # place on btn Go
+        + [BUTTON_ENTER]  # press Go without any value should not present any error
         + (
             # 4 press change to number "F"
             [BUTTON_PAGE_PREV, BUTTON_PAGE_PREV, BUTTON_PAGE_PREV, BUTTON_PAGE_PREV]
@@ -934,8 +934,8 @@ def test_load_12w_from_octal(m5stickv, mocker, mocker_printer):
 
     BTN_SEQUENCE = (
         [BUTTON_ENTER]  # 1 press confirm msg
-        + [BUTTON_PAGE_PREV] # place on btn Go
-        + [BUTTON_ENTER] # press Go without any value should not present any error
+        + [BUTTON_PAGE_PREV]  # place on btn Go
+        + [BUTTON_ENTER]  # press Go without any value should not present any error
         + (
             # 4 press change to number "7"
             [BUTTON_PAGE_PREV] * 4

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -728,11 +728,13 @@ def test_create_key_from_text(m5stickv, mocker):
 
 def test_load_key_from_digits(m5stickv, mocker, mocker_printer):
     from krux.pages.login import Login
-    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
 
     cases = [
         (
             [BUTTON_ENTER]  # 1 press confirm msg
+            + [BUTTON_PAGE_PREV] # place on btn Go
+            + [BUTTON_ENTER] # press Go without any value should not present any error
             + (
                 # 1 press change to number "2" and 1 press to select
                 [BUTTON_PAGE, BUTTON_ENTER]
@@ -826,6 +828,8 @@ def test_load_12w_from_hexadecimal(m5stickv, mocker, mocker_printer):
 
     BTN_SEQUENCE = (
         [BUTTON_ENTER]  # 1 press confirm msg
+        + [BUTTON_PAGE_PREV] # place on btn Go
+        + [BUTTON_ENTER] # press Go without any value should not present any error
         + (
             # 4 press change to number "F"
             [BUTTON_PAGE_PREV, BUTTON_PAGE_PREV, BUTTON_PAGE_PREV, BUTTON_PAGE_PREV]
@@ -930,6 +934,8 @@ def test_load_12w_from_octal(m5stickv, mocker, mocker_printer):
 
     BTN_SEQUENCE = (
         [BUTTON_ENTER]  # 1 press confirm msg
+        + [BUTTON_PAGE_PREV] # place on btn Go
+        + [BUTTON_ENTER] # press Go without any value should not present any error
         + (
             # 4 press change to number "7"
             [BUTTON_PAGE_PREV] * 4


### PR DESCRIPTION
### What is this PR for?
Fix errors when `Loading Mnemonic > Via Manual Input > Word Numbers` and input is empty and user click on "GO" btn:
- ValueError: invalid literal for int() with base 10: ''
- ValueError: invalid literal for int() with base 16: ''
- ValueError: invalid literal for int() with base 8: ''

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
