### PR TITLE
Fixed keypad touch index stuck after "ESC" > "No"

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -176,6 +176,10 @@ class Page:
                     if esc_prompt:
                         if self.esc_prompt() == ESC_KEY:
                             return ESC_KEY
+                        if self.ctx.input.touch is not None:
+                            self.ctx.input.touch.set_regions(
+                                pad.layout.x_keypad_map, pad.layout.y_keypad_map
+                            )
                     else:
                         return ESC_KEY
                 elif pad.cur_key_index == pad.go_index:
@@ -343,9 +347,7 @@ class Page:
         y_key_map += 4 * FONT_HEIGHT
         self.y_keypad_map.append(min(y_key_map, self.ctx.display.height()))
         if self.ctx.input.touch is not None:
-            self.ctx.input.touch.clear_regions()
-            self.ctx.input.touch.x_regions = self.x_keypad_map
-            self.ctx.input.touch.y_regions = self.y_keypad_map
+            self.ctx.input.touch.set_regions(self.x_keypad_map, self.y_keypad_map)
         btn = None
         answer = True
         while btn != BUTTON_ENTER:

--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -66,8 +66,7 @@ class KeypadLayout:
             x * key_h_spacing + MINIMAL_PADDING for x in range(self.width + 1)
         ]
         if ctx.input.touch is not None:
-            ctx.input.touch.y_regions = self.y_keypad_map
-            ctx.input.touch.x_regions = self.x_keypad_map
+            ctx.input.touch.set_regions(self.x_keypad_map, self.y_keypad_map)
 
 
 class Keypad:
@@ -96,19 +95,27 @@ class Keypad:
     @property
     def total_keys(self):
         """Returns the total number of keys in the current keyset, including fixed"""
-        return len(self.keys) + FIXED_KEYS + (1 if len(self.keysets) > 1 else 0)
+        return len(self.keys) + FIXED_KEYS + self.count_more_key()
 
     @property
     def more_index(self):
         """Returns the index of the "More" key"""
-        if len(self.keysets) > 1:
+        if self.has_more_key():
             return self.del_index - 1
         return None
 
     @property
     def del_index(self):
         """Returns the index of the "Del" key"""
-        return len(self.keys) + self.empty_keys + (1 if len(self.keysets) > 1 else 0)
+        return len(self.keys) + self.empty_keys + self.count_more_key()
+
+    def has_more_key(self):
+        """If keypad has "ABC" key"""
+        return len(self.keysets) > 1
+
+    def count_more_key(self):
+        """Count 1 if has the more key"""
+        return 1 if self.has_more_key() else 0
 
     @property
     def esc_index(self):
@@ -155,7 +162,7 @@ class Keypad:
                 elif key_index == self.go_index:
                     key = t("Go")
                     custom_color = theme.go_color
-                elif key_index == self.more_index and len(self.keysets) > 1:
+                elif self.has_more_key() and key_index == self.more_index:
                     key = self.keysets[self._move_keyset_index()][:3]
                     custom_color = theme.toggle_color
 
@@ -209,7 +216,7 @@ class Keypad:
 
     def draw_keyset_index(self):
         """Indicates the current keyset index with a small circle"""
-        if len(self.keysets) == 1:
+        if not self.has_more_key():
             return
         bar_height = FONT_HEIGHT // 6
         bar_length = FONT_WIDTH
@@ -309,13 +316,13 @@ class Keypad:
 
     def next_keyset(self):
         """Change keys for the next keyset"""
-        if len(self.keysets) > 1:
+        if self.has_more_key():
             self.keyset_index = self._move_keyset_index()
             self.reset()
 
     def previous_keyset(self):
         """Change keys for the previous keyset"""
-        if len(self.keysets) > 1:
+        if self.has_more_key():
             self.keyset_index = self._move_keyset_index(False)
             self.reset()
 

--- a/src/krux/touch.py
+++ b/src/krux/touch.py
@@ -156,6 +156,24 @@ class Touch:
 
         return index
 
+    def set_regions(self, x_list=None, y_list=None):
+        """Set buttons map regions x and y"""
+        if x_list:
+            if isinstance(x_list, list):
+                self.x_regions = x_list
+            else:
+                raise ValueError("x_list must be a list")
+        else:
+            self.x_regions = []
+
+        if y_list:
+            if isinstance(y_list, list):
+                self.y_regions = y_list
+            else:
+                raise ValueError("y_list must be a list")
+        else:
+            self.y_regions = []
+
     def _store_points(self, data):
         """Store pressed points and calculare an average pressed point"""
 

--- a/tests/pages/test_page.py
+++ b/tests/pages/test_page.py
@@ -206,6 +206,27 @@ def get_frame_titles_resulting_from_input(
     return frame_titles
 
 
+def test_keypad_esc_no_exit(mocker, amigo):
+    from krux.pages import Page, LETTERS
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV
+
+    btn_seq = (
+        [BUTTON_PAGE_PREV] * 2  # go to ESC
+        + [BUTTON_ENTER]  # press ESC to exit
+        + [BUTTON_PAGE_PREV, BUTTON_ENTER]  # No
+        + [BUTTON_ENTER]  # press ESC to exit
+        + [BUTTON_ENTER]  # Yes
+    )
+
+    ctx = create_ctx(mocker, btn_seq)
+    assert ctx.input.touch is not None
+
+    page = Page(ctx)
+    page.capture_from_keypad("test", [LETTERS])
+
+    assert ctx.input.touch.set_regions.call_count == 4
+
+
 def test_keypad_swipe_hint_is_shown_after_more_keypress_and_cleared_after_other_keypress(
     mocker, amigo, mock_page_cls
 ):

--- a/tests/test_touch.py
+++ b/tests/test_touch.py
@@ -32,3 +32,30 @@ def test_touch_event(mocker, amigo):
         event = touch.event(validate_position=True)
     assert event == False
     assert touch.current_index() == 3
+
+
+def test_set_regions(mocker, amigo):
+    from krux.touch import Touch
+    import board
+    import pytest
+
+    touch = Touch(
+        board.config["lcd"]["width"],
+        board.config["lcd"]["height"],
+        board.config["krux"]["pins"]["TOUCH_IRQ"],
+    )
+
+    touch.set_regions()
+
+    assert touch.x_regions == touch.y_regions == []
+
+    with pytest.raises(ValueError, match="x_list must be a list"):
+        touch.set_regions(1)
+
+    with pytest.raises(ValueError, match="y_list must be a list"):
+        touch.set_regions(None, 1)
+
+    touch.set_regions([1, 2, 3], [4, 5, 6])
+
+    assert touch.x_regions == [1, 2, 3]
+    assert touch.y_regions == [4, 5, 6]


### PR DESCRIPTION
### What is this PR for?
- Using touch only, when on any keypad and hit "ESC" then "No", then the keypad would stuck responding only index 0,0 everytime, regardless of the place touched


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
