### PR TITLE
Text with highlight colours

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -535,7 +535,7 @@ max-bool-expr=5
 max-branches=22
 
 # Maximum number of locals for function / method body.
-max-locals=26
+max-locals=27
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -375,6 +375,7 @@ class Display:
         bg_color=theme.bg_color,
         info_box=False,
         max_lines=None,
+        highlight_prefix="",
     ) -> int:
         """Draws text horizontally-centered on the display, at the given offset_y"""
         lines = (
@@ -406,14 +407,28 @@ class Display:
                     color,
                     bg_color,
                 )
+                if highlight_prefix:
+                    prefix_index = line.find(highlight_prefix)
+                    if prefix_index > -1:
+                        self.draw_string(
+                            offset_x,
+                            offset_y + (i * (FONT_HEIGHT)),
+                            line[: prefix_index + len(highlight_prefix)],
+                            color=theme.highlight_color,
+                        )
+
         return len(lines)  # return number of lines drawn
 
-    def draw_centered_text(self, text, color=theme.fg_color, bg_color=theme.bg_color):
+    def draw_centered_text(
+        self, text, color=theme.fg_color, bg_color=theme.bg_color, highlight_prefix=""
+    ):
         """Draws text horizontally and vertically centered on the display"""
         lines = text if isinstance(text, list) else self.to_lines(text)
         lines_height = len(lines) * FONT_HEIGHT
         offset_y = max(0, (self.height() - lines_height) // 2)
-        self.draw_hcentered_text(text, offset_y, color, bg_color)
+        self.draw_hcentered_text(
+            text, offset_y, color, bg_color, highlight_prefix=highlight_prefix
+        )
 
     def flash_text(self, text, color=theme.fg_color, duration=FLASH_MSG_TIME):
         """Flashes text centered on the display for duration ms"""

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -292,6 +292,10 @@ class Page:
         header = "BIP39 {}{}".format(suffix, fingerprint)
         self.ctx.display.clear()
         self.ctx.display.draw_hcentered_text(header)
+        if fingerprint:
+            self.ctx.display.draw_hcentered_text(
+                fingerprint, color=theme.highlight_color
+            )
         lines = self.ctx.display.to_lines(header)
         starting_y_offset = DEFAULT_PADDING // 4 + (
             len(lines) * FONT_HEIGHT + FONT_HEIGHT
@@ -305,6 +309,10 @@ class Page:
                 self.ctx.input.wait_for_button()
                 self.ctx.display.clear()
                 self.ctx.display.draw_hcentered_text(header)
+                if fingerprint:
+                    self.ctx.display.draw_hcentered_text(
+                        fingerprint, color=theme.highlight_color
+                    )
                 for i, word in enumerate(word_list[12:]):
                     self.ctx.display.draw_string(
                         DEFAULT_PADDING, starting_y_offset + (i * FONT_HEIGHT), word

--- a/src/krux/pages/file_manager.py
+++ b/src/krux/pages/file_manager.py
@@ -166,31 +166,51 @@ class FileManager(Page):
         """Display the file details on the device's screen"""
         import uos
         import time
+        from ..display import DEFAULT_PADDING, FONT_HEIGHT
+        from ..themes import theme
 
         stats = uos.stat(file)
         size_KB = stats[6] / 1024
         size_KB_fraction = str(int(size_KB * 100))[-2:]
         created = time.localtime(stats[9])
         modified = time.localtime(stats[8])
-        format_datetime = " %s-%02d-%02d %02d:%02d"
+        format_datetime = "%s-%02d-%02d %02d:%02d"
         file = file[4:]  # remove "/sd/" prefix
 
         self.ctx.display.clear()
-        self.ctx.display.draw_hcentered_text(
-            file
-            + "\n\n"
-            + t("Size:")
-            + " "
-            + generate_thousands_separator(int(size_KB))
-            + render_decimal_separator()
-            + size_KB_fraction
-            + " KB"
-            + "\n\n"
-            + t("Created:")
-            + format_datetime % created[:5]
-            + "\n\n"
-            + t("Modified:")
-            + format_datetime % modified[:5]
+        offset_y = DEFAULT_PADDING
+        offset_y += (
+            self.ctx.display.draw_hcentered_text(
+                file
+                + "\n\n"
+                + t("Size:")
+                + " "
+                + generate_thousands_separator(int(size_KB))
+                + render_decimal_separator()
+                + size_KB_fraction
+                + " KB"
+                + "\n\n",
+                offset_y,
+                highlight_prefix=":",
+            )
+            * FONT_HEIGHT
         )
+        offset_y += (
+            self.ctx.display.draw_hcentered_text(
+                t("Created:"), offset_y, color=theme.highlight_color
+            )
+        ) * FONT_HEIGHT
+        offset_y += (
+            self.ctx.display.draw_hcentered_text(
+                format_datetime % created[:5] + "\n\n", offset_y
+            )
+            * FONT_HEIGHT
+        )
+        offset_y += (
+            self.ctx.display.draw_hcentered_text(
+                t("Modified:"), offset_y, color=theme.highlight_color
+            )
+        ) * FONT_HEIGHT
+        self.ctx.display.draw_hcentered_text(format_datetime % modified[:5], offset_y)
 
         return file

--- a/src/krux/pages/home_pages/bip85.py
+++ b/src/krux/pages/home_pages/bip85.py
@@ -80,6 +80,7 @@ class Bip85(Page):
         self.ctx.display.clear()
 
         from ...key import Key
+        from ...themes import theme
 
         key = Key(
             bip85_words,
@@ -94,7 +95,9 @@ class Bip85(Page):
                 fingerprint=key.fingerprint_hex_str(True),
             )
         else:
-            self.ctx.display.draw_centered_text(key.fingerprint_hex_str(True))
+            self.ctx.display.draw_centered_text(
+                key.fingerprint_hex_str(True), color=theme.highlight_color
+            )
         if self.prompt(t("Load?"), BOTTOM_PROMPT_LINE):
             from ...wallet import Wallet
 

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -361,7 +361,7 @@ class Home(Page):
 
         for message in outputs:
             self.ctx.display.clear()
-            self.ctx.display.draw_centered_text(message)
+            self.ctx.display.draw_centered_text(message, highlight_prefix=":")
             self.ctx.input.wait_for_button()
 
         # memory management

--- a/src/krux/pages/home_pages/pub_key_view.py
+++ b/src/krux/pages/home_pages/pub_key_view.py
@@ -59,6 +59,8 @@ class PubkeyView(Page):
             )
 
         def _pub_key_text(version):
+            from ...themes import theme
+
             pub_text_menu_items = [
                 (
                     t("Save to SD card"),
@@ -75,12 +77,17 @@ class PubkeyView(Page):
             pub_key_menu = Menu(self.ctx, pub_text_menu_items, offset=menu_offset)
             self.ctx.display.clear()
             self.ctx.display.draw_hcentered_text(
-                self.ctx.wallet.key.fingerprint_hex_str(pretty=True)
-                + "\n\n"
+                "\n\n"
                 + self.ctx.wallet.key.derivation_str(pretty=True)
                 + "\n\n"
                 + full_pub_key,
                 offset_y=FONT_HEIGHT,
+                info_box=True,
+            )
+            self.ctx.display.draw_hcentered_text(
+                self.ctx.wallet.key.fingerprint_hex_str(pretty=True),
+                offset_y=FONT_HEIGHT,
+                color=theme.highlight_color,
                 info_box=True,
             )
             pub_key_menu.run_loop()

--- a/src/krux/pages/home_pages/wallet_descriptor.py
+++ b/src/krux/pages/home_pages/wallet_descriptor.py
@@ -36,7 +36,11 @@ from ...display import (
 )
 from ...krux_settings import t
 from ...qr import FORMAT_NONE, FORMAT_PMOFN
-from ...sd_card import DESCRIPTOR_FILE_EXTENSION, JSON_FILE_EXTENSION
+from ...sd_card import (
+    DESCRIPTOR_FILE_EXTENSION,
+    JSON_FILE_EXTENSION,
+    PUBKEY_FILE_EXTENSION,
+)
 from ...themes import theme
 from ...key import FINGERPRINT_SYMBOL, DERIVATION_PATH_SYMBOL, P2TR
 
@@ -105,7 +109,12 @@ class WalletDescriptor(Page):
 
                 utils = Utils(self.ctx)
                 _, wallet_data = utils.load_file(
-                    (DESCRIPTOR_FILE_EXTENSION, JSON_FILE_EXTENSION), prompt=False
+                    (
+                        DESCRIPTOR_FILE_EXTENSION,
+                        JSON_FILE_EXTENSION,
+                        PUBKEY_FILE_EXTENSION,
+                    ),
+                    prompt=False,
                 )
                 persisted = True
             except OSError:
@@ -171,6 +180,7 @@ class WalletDescriptor(Page):
 
     def display_loading_wallet(self, wallet):
         """Displays wallet descriptor attributes while loading"""
+        from ...settings import THIN_SPACE
 
         def draw_header():
             nonlocal offset_y
@@ -191,7 +201,7 @@ class WalletDescriptor(Page):
                 if (wallet.is_multisig() or wallet.is_miniscript())
                 else (" " * 3 if not MINIMAL_DISPLAY else "")
             )
-            key_fingerprint = FINGERPRINT_SYMBOL + " "
+            key_fingerprint = FINGERPRINT_SYMBOL + THIN_SPACE
             if key.origin:
                 key_origin_str = str(key.origin)
                 key_fingerprint += key_origin_str[:8]

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -314,6 +314,7 @@ class Login(Page):
             script_type = P2WSH
         derivation_path = ""
         from ..wallet import Wallet
+        from ..themes import theme
 
         while True:
             key = Key(
@@ -327,7 +328,7 @@ class Login(Page):
             )
             if not derivation_path:
                 derivation_path = key.derivation
-            wallet_info = key.fingerprint_hex_str(True) + "\n"
+            wallet_info = "\n"
             wallet_info += network["name"] + "\n"
             if policy_type == TYPE_SINGLESIG:
                 wallet_info += NAME_SINGLE_SIG + "\n"
@@ -354,6 +355,12 @@ class Login(Page):
                     * FONT_HEIGHT
                     + DEFAULT_PADDING
                 ),
+            )
+            # draw fingerprint with highlight color
+            self.ctx.display.draw_hcentered_text(
+                key.fingerprint_hex_str(True),
+                color=theme.highlight_color,
+                info_box=True,
             )
             index, _ = submenu.run_loop()
             if index == len(submenu.menu) - 1:

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -154,7 +154,7 @@ class Tools(Page):
         """Handler for the 'Descriptor Addresses' menu item"""
         from .home_pages.wallet_descriptor import WalletDescriptor
         from .home_pages.addresses import Addresses
-        from krux.wallet import Wallet
+        from ..wallet import Wallet
 
         self.ctx.wallet = Wallet(None)
         menu_result = WalletDescriptor(self.ctx).wallet()

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -96,7 +96,8 @@ class Tools(Page):
                     + t("Free:")
                     + " "
                     + generate_thousands_separator(sd_free_MB)
-                    + " MB"
+                    + " MB",
+                    highlight_prefix=":",
                 )
                 if self.prompt(t("Explore files?"), BOTTOM_PROMPT_LINE):
                     from .file_manager import FileManager

--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -569,7 +569,7 @@ def is_double_mnemonic(mnemonic: str):
 
     words = mnemonic.split(" ")
     if len(words) > 12:
-        from krux.bip39 import k_mnemonic_is_valid
+        from .bip39 import k_mnemonic_is_valid
 
         if (
             k_mnemonic_is_valid(" ".join(words[:12]))

--- a/tests/pages/home_pages/test_bip85.py
+++ b/tests/pages/home_pages/test_bip85.py
@@ -7,6 +7,7 @@ def test_bip85_bip39_mnemonic_derivation(mocker, amigo, tdata):
     from krux.pages.home_pages.bip85 import Bip85
     from krux.wallet import Wallet
     from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
+    from krux.themes import theme
 
     cases = [
         # case
@@ -174,7 +175,9 @@ def test_bip85_bip39_mnemonic_derivation(mocker, amigo, tdata):
     bip85_ui = Bip85(ctx)
     mocker.spy(bip85_ui, "display_mnemonic")
     bip85_ui.export()
-    ctx.display.draw_centered_text.assert_called_with("⊚" + THIN_SPACE + "%s" % case[3])
+    ctx.display.draw_centered_text.assert_called_with(
+        "⊚" + THIN_SPACE + "%s" % case[3], color=theme.highlight_color
+    )
 
 
 def test_bip85_base64_password_derivation(mocker, amigo, tdata):

--- a/tests/pages/test_file_manager.py
+++ b/tests/pages/test_file_manager.py
@@ -23,6 +23,8 @@ def test_file_exploring(m5stickv, mocker, mock_file_operations):
     from krux.pages.file_manager import FileManager
     from krux.input import BUTTON_ENTER, BUTTON_PAGE
     import time
+    from krux.display import DEFAULT_PADDING
+    from krux.themes import theme
 
     BTN_SEQUENCE = (
         [BUTTON_PAGE]  # move to second entry, last directory
@@ -58,8 +60,22 @@ def test_file_exploring(m5stickv, mocker, mock_file_operations):
     ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "file2_has_a_long_name\n\nSize: 1.1 KB\n\nCreated: 1970-01-01 00:00\n\nModified: 1970-01-01 00:00"
-            )
+                "file2_has_a_long_name\n\nSize: 1.1 KB\n\n",
+                DEFAULT_PADDING,
+                highlight_prefix=":",
+            ),
+            mocker.call(
+                "Created:",
+                24,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00\n\n", 38),
+            mocker.call(
+                "Modified:",
+                52,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00", 66),
         ]
     )
 
@@ -69,6 +85,8 @@ def test_file_load(m5stickv, mocker, mock_file_operations):
     from krux.input import BUTTON_ENTER, BUTTON_PAGE
     from krux.sd_card import DESCRIPTOR_FILE_EXTENSION
     import time
+    from krux.display import DEFAULT_PADDING
+    from krux.themes import theme
 
     BTN_SEQUENCE = (
         [BUTTON_PAGE]  # move to second entry, last directory
@@ -120,8 +138,22 @@ def test_file_load(m5stickv, mocker, mock_file_operations):
     ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "file2_has_a_long_name.txt\n\nSize: 1.1 KB\n\nCreated: 1970-01-01 00:00\n\nModified: 1970-01-01 00:00"
-            )
+                "file2_has_a_long_name.txt\n\nSize: 1.1 KB\n\n",
+                DEFAULT_PADDING,
+                highlight_prefix=":",
+            ),
+            mocker.call(
+                "Created:",
+                24,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00\n\n", 38),
+            mocker.call(
+                "Modified:",
+                52,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00", 66),
         ]
     )
 
@@ -131,6 +163,8 @@ def test_file_load_cancel(m5stickv, mocker, mock_file_operations):
     from krux.input import BUTTON_ENTER, BUTTON_PAGE
     from krux.sd_card import DESCRIPTOR_FILE_EXTENSION
     import time
+    from krux.display import DEFAULT_PADDING
+    from krux.themes import theme
 
     BTN_SEQUENCE = (
         [BUTTON_PAGE]  # move to second entry, last directory
@@ -185,8 +219,22 @@ def test_file_load_cancel(m5stickv, mocker, mock_file_operations):
     ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "file2_has_a_long_name.txt\n\nSize: 1.1 KB\n\nCreated: 1970-01-01 00:00\n\nModified: 1970-01-01 00:00"
-            )
+                "file2_has_a_long_name.txt\n\nSize: 1.1 KB\n\n",
+                DEFAULT_PADDING,
+                highlight_prefix=":",
+            ),
+            mocker.call(
+                "Created:",
+                24,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00\n\n", 38),
+            mocker.call(
+                "Modified:",
+                52,
+                color=theme.highlight_color,
+            ),
+            mocker.call("1970-01-01 00:00", 66),
         ]
     )
 

--- a/tests/pages/test_tools.py
+++ b/tests/pages/test_tools.py
@@ -99,7 +99,12 @@ def test_sd_check(m5stickv, mocker, mock_file_operations):
     tool = Tools(ctx)
     tool.sd_check()
     ctx.display.draw_hcentered_text.assert_has_calls(
-        [mocker.call("SD card\n\nSize: 16 MB\n\nUsed: 12 MB\n\nFree: 4 MB")]
+        [
+            mocker.call(
+                "SD card\n\nSize: 16 MB\n\nUsed: 12 MB\n\nFree: 4 MB",
+                highlight_prefix=":",
+            )
+        ]
     )
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -566,7 +566,7 @@ def test_draw_centered_text(mocker, m5stickv):
     d.draw_centered_text("Hello world", krux.display.lcd.WHITE, 0)
 
     d.draw_hcentered_text.assert_called_with(
-        "Hello world", 113, krux.display.lcd.WHITE, 0
+        "Hello world", 113, krux.display.lcd.WHITE, 0, highlight_prefix=""
     )
 
 


### PR DESCRIPTION
### What is this PR for?
Adjusting screen texts to use highlight colors:
- The fingerprint on various screens
- PSBT preview (matching highlight color for prefixes, like message sign to addresss)
- File manager prefixes

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
