### PR TITLE
Fix load tiny seed with button only then use touch on mnemonic editor

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -476,6 +476,48 @@ class Page:
         _, status = self.menu.run_loop(start_from_index)
         return status != MENU_SHUTDOWN
 
+    def draw_proceed_menu(
+        self, go_txt, esc_txt, y_offset=0, menu_index=None, go_enabled=True
+    ):
+        """Reusable 'Esc' and 'Go' menu choice"""
+        go_x_offset = (
+            self.ctx.display.width() // 2 - lcd.string_width_px(go_txt)
+        ) // 2 + self.ctx.display.width() // 2
+        esc_x_offset = (
+            self.ctx.display.width() // 2 - lcd.string_width_px(esc_txt)
+        ) // 2
+        go_esc_y_offset = (
+            self.ctx.display.height() - (y_offset + FONT_HEIGHT + MINIMAL_PADDING)
+        ) // 2 + y_offset
+        if menu_index == 0 and self.ctx.input.buttons_active:
+            self.ctx.display.outline(
+                DEFAULT_PADDING,
+                go_esc_y_offset - FONT_HEIGHT // 2,
+                self.ctx.display.width() // 2 - 2 * DEFAULT_PADDING,
+                FONT_HEIGHT + FONT_HEIGHT,
+                theme.error_color,
+            )
+        self.ctx.display.draw_string(
+            esc_x_offset, go_esc_y_offset, esc_txt, theme.error_color
+        )
+        if menu_index == 1 and self.ctx.input.buttons_active:
+            self.ctx.display.outline(
+                self.ctx.display.width() // 2 + DEFAULT_PADDING,
+                go_esc_y_offset - FONT_HEIGHT // 2,
+                self.ctx.display.width() // 2 - 2 * DEFAULT_PADDING,
+                FONT_HEIGHT + FONT_HEIGHT,
+                theme.go_color,
+            )
+        go_color = theme.go_color if go_enabled else theme.disabled_color
+        self.ctx.display.draw_string(go_x_offset, go_esc_y_offset, go_txt, go_color)
+        if not self.ctx.input.buttons_active:
+            self.ctx.display.draw_vline(
+                self.ctx.display.width() // 2,
+                go_esc_y_offset,
+                FONT_HEIGHT,
+                theme.frame_color,
+            )
+
 
 class ListView:
     """Acts as a fixed-size, sliding window over an underlying list"""
@@ -879,42 +921,3 @@ def choose_len_mnemonic(ctx, extra_option=""):
     _, num_words = submenu.run_loop()
     ctx.display.clear()
     return num_words
-
-
-def proceed_menu(
-    ctx, y_offset=0, menu_index=None, proceed_txt="Go", esc_txt="Esc", go_enabled=True
-):
-    """Reusable 'Esc' and 'Go' menu choice"""
-    go_x_offset = (
-        ctx.display.width() // 2 - lcd.string_width_px(proceed_txt)
-    ) // 2 + ctx.display.width() // 2
-    esc_x_offset = (ctx.display.width() // 2 - lcd.string_width_px(esc_txt)) // 2
-    go_esc_y_offset = (
-        ctx.display.height() - (y_offset + FONT_HEIGHT + MINIMAL_PADDING)
-    ) // 2 + y_offset
-    if menu_index == 0 and ctx.input.buttons_active:
-        ctx.display.outline(
-            DEFAULT_PADDING,
-            go_esc_y_offset - FONT_HEIGHT // 2,
-            ctx.display.width() // 2 - 2 * DEFAULT_PADDING,
-            FONT_HEIGHT + FONT_HEIGHT,
-            theme.error_color,
-        )
-    ctx.display.draw_string(esc_x_offset, go_esc_y_offset, esc_txt, theme.error_color)
-    if menu_index == 1 and ctx.input.buttons_active:
-        ctx.display.outline(
-            ctx.display.width() // 2 + DEFAULT_PADDING,
-            go_esc_y_offset - FONT_HEIGHT // 2,
-            ctx.display.width() // 2 - 2 * DEFAULT_PADDING,
-            FONT_HEIGHT + FONT_HEIGHT,
-            theme.go_color,
-        )
-    go_color = theme.go_color if go_enabled else theme.disabled_color
-    ctx.display.draw_string(go_x_offset, go_esc_y_offset, proceed_txt, go_color)
-    if not ctx.input.buttons_active:
-        ctx.display.draw_vline(
-            ctx.display.width() // 2,
-            go_esc_y_offset,
-            FONT_HEIGHT,
-            theme.frame_color,
-        )

--- a/src/krux/pages/mnemonic_editor.py
+++ b/src/krux/pages/mnemonic_editor.py
@@ -22,7 +22,7 @@
 
 from embit import bip39
 from embit.wordlists.bip39 import WORDLIST
-from . import Page, ESC_KEY, LETTERS, proceed_menu
+from . import Page, ESC_KEY, LETTERS
 from ..display import DEFAULT_PADDING, MINIMAL_PADDING, FONT_HEIGHT, NARROW_SCREEN_WITH
 from ..krux_settings import t
 from ..themes import theme
@@ -239,8 +239,8 @@ class MnemonicEditor(Page):
         menu_index = None
         if self.ctx.input.buttons_active and button_index >= ESC_INDEX:
             menu_index = button_index - ESC_INDEX
-        proceed_menu(
-            self.ctx, y_region, menu_index, go_txt, esc_txt, self.valid_checksum
+        self.draw_proceed_menu(
+            go_txt, esc_txt, y_region, menu_index, self.valid_checksum
         )
 
     def edit_word(self, index):

--- a/src/krux/pages/mnemonic_editor.py
+++ b/src/krux/pages/mnemonic_editor.py
@@ -160,12 +160,12 @@ class MnemonicEditor(Page):
         word_v_padding = self.ctx.display.height() * 3 // 4
         word_v_padding //= 12
 
-        if self.ctx.input.touch is not None and not self.ctx.input.buttons_active:
+        if self.ctx.input.touch is not None:
             self.ctx.input.touch.clear_regions()
             self.ctx.input.touch.x_regions.append(0)
             self.ctx.input.touch.x_regions.append(self.ctx.display.width() // 2)
             self.ctx.input.touch.x_regions.append(self.ctx.display.width())
-            if self.mnemonic_length == 24:
+            if not self.ctx.input.buttons_active and self.mnemonic_length == 24:
                 self.ctx.display.draw_vline(
                     self.ctx.display.width() // 2,
                     self.header_offset,
@@ -174,12 +174,13 @@ class MnemonicEditor(Page):
                 )
             y_region = self.header_offset
             for _ in range(13):
-                self.ctx.display.draw_hline(
-                    MINIMAL_PADDING,
-                    y_region,
-                    self.ctx.display.width() - 2 * MINIMAL_PADDING,
-                    theme.frame_color,
-                )
+                if not self.ctx.input.buttons_active:
+                    self.ctx.display.draw_hline(
+                        MINIMAL_PADDING,
+                        y_region,
+                        self.ctx.display.width() - 2 * MINIMAL_PADDING,
+                        theme.frame_color,
+                    )
                 self.ctx.input.touch.y_regions.append(y_region)
                 y_region += word_v_padding
             self.ctx.input.touch.y_regions.append(self.ctx.display.height())

--- a/src/krux/pages/tiny_seed.py
+++ b/src/krux/pages/tiny_seed.py
@@ -26,7 +26,7 @@ import image
 import sensor
 import time
 from embit.wordlists.bip39 import WORDLIST
-from . import Page, FLASH_MSG_TIME, proceed_menu
+from . import Page, FLASH_MSG_TIME
 from ..themes import theme
 from ..wdt import wdt
 from ..krux_settings import t
@@ -367,7 +367,7 @@ class TinySeed(Page):
                 if index >= TS_GO_POSITION
                 else (0 if index >= TS_ESC_START_POSITION else None)
             )
-            proceed_menu(self.ctx, menu_offset, menu_index, t("Go"), t("Esc"))
+            self.draw_proceed_menu(t("Go"), t("Esc"), menu_offset, menu_index)
             if self.ctx.input.buttons_active:
                 self._draw_index(index)
             btn = self.ctx.input.wait_for_button()

--- a/src/krux/touch.py
+++ b/src/krux/touch.py
@@ -153,7 +153,6 @@ class Touch:
             index = y_index
 
         # self.highlight_region(x_index, y_index)
-
         return index
 
     def set_regions(self, x_list=None, y_list=None):

--- a/tests/pages/test_mnemonic_editor.py
+++ b/tests/pages/test_mnemonic_editor.py
@@ -254,3 +254,15 @@ def test_edit_existing_mnemonic_using_touch(mocker, amigo):
         else:
             assert edited_mnemonic == EDITED_MNEMONIC_12W
         assert ctx.input.wait_for_button.call_count == len(touch_seq)
+
+
+def test_button_used_but_touch_enabled(mocker, amigo):
+    from krux.pages.mnemonic_editor import MnemonicEditor
+    from krux.input import BUTTON_TOUCH, BUTTON_ENTER, BUTTON_PAGE_PREV
+
+    mnemonic = "olympic cabbage tissue route sense program under choose bean emerge velvet vendor"
+    ctx = create_ctx(mocker, None)
+    mnemonic_editor = MnemonicEditor(ctx, mnemonic)
+    mnemonic_editor._map_words()
+    ctx.input.touch.x_regions.append.assert_called()
+    ctx.input.touch.y_regions.append.assert_called()


### PR DESCRIPTION
### What is this PR for?
- Error appears when load Tiny seed using buttons on Amigo and then on mnemonic editor use touch to click on a word 
- [x] TODO: implement a test to prove the error existed and was fixed

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
