### PR TITLE
added command update-copywrite to krux bash script

### DIFF
--- a/krux
+++ b/krux
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-# Copyright (c) 2021-2023 Krux contributors
+# Copyright (c) 2021-2025 Krux contributors
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -265,6 +265,38 @@ elif [ "$1" == "build-release" ]; then
 elif [ "$1" == "clean" ]; then
     rm -rf build
     docker system prune
+elif [ "$1" == "update-copywrite" ]; then
+    old_year=$2
+    new_year=$3
+    # Define the old and new copyright text
+    OLD_TEXT="# Copyright (c) 2021-$old_year Krux contributors"
+    NEW_TEXT="# Copyright (c) 2021-$new_year Krux contributors"
+
+    # Find Python files inside src/ (including subdirectories) that contain the old copyright text
+    FILES=$(grep -rl --include="*.py" "$OLD_TEXT" src)
+
+    # If no files are found, exit
+    if [ -z "$FILES" ]; then
+        echo "No Python files in 'src/' need updating."
+        exit 0
+    fi
+
+    # Display files that will be modified
+    echo "The following Python files in 'src/' and its subdirectories will be updated:"
+    echo "$FILES"
+    echo ""
+
+    # Prompt user for confirmation
+    read -p "Update copyright in these files? (y/n): " CONFIRM
+
+    # If user agrees, perform the replacement
+    if [[ "$CONFIRM" =~ ^[Yy]$ ]]; then
+        echo "Updating files..."
+        echo "$FILES" | xargs sed -i'' -e "s|$OLD_TEXT|$NEW_TEXT|g"
+        echo "Copyright year updated successfully."
+    else
+        echo "Update canceled."
+    fi
 else
     echo "Missing argument"
 fi


### PR DESCRIPTION
### What is this PR for?

Fixes #526  

### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other

### Description

Every year is necessary to update the preliminary comment on python files. These comments have the MIT license and the year in format

```python
# Copyright (c) 2021-<current year> Krux contributors
```

This command help developers to automatically update these commands without go through all files, e.g:

```bash
# update all python files that have 2024 to 2025
./krux update-copywrite 2024 2025.
```

Is interesting to note that this can be added to a schedule on CI yearly.