### PR TITLE
Reset derivation (even if it was set custom for Miniscript)

### DIFF
--- a/src/krux/key.py
+++ b/src/krux/key.py
@@ -113,7 +113,7 @@ class Key:
         passphrase="",
         account_index=0,
         script_type=P2WPKH,
-        custom_derivation="",
+        derivation="",
     ):
         self.mnemonic = mnemonic
         self.policy_type = policy_type
@@ -129,14 +129,12 @@ class Key:
             bip39.mnemonic_to_seed(mnemonic, passphrase), version=network["xprv"]
         )
         self.fingerprint = self.root.child(0).fingerprint
-        if not custom_derivation:
+        if not derivation:
             self.derivation = self.get_default_derivation(
                 self.policy_type, self.network, self.account_index, self.script_type
             )
-            self.custom_derivation = False
         else:
-            self.derivation = custom_derivation
-            self.custom_derivation = True
+            self.derivation = derivation
         self.account = self.root.derive(self.derivation).to_public()
 
     def xpub(self, version=None):

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -173,11 +173,12 @@ class WalletSettings(Page):
             if index == 0:
                 new_network = self._coin_type()
                 if new_network is not None:
-                    network = new_network
                     derivation_path = ""
+                    network = new_network
             elif index == 1:
                 new_policy_type = self._policy_type()
                 if new_policy_type is not None:
+                    derivation_path = ""
                     policy_type = new_policy_type
                     if policy_type == TYPE_SINGLESIG and script_type == P2WSH:
                         # If is single-sig, and script is p2wsh, force to pick a new type
@@ -195,7 +196,6 @@ class WalletSettings(Page):
                         # If is miniscript, pick P2WSH or P2TR
                         script_type = self._miniscript_type()
                         script_type = P2WSH if script_type is None else script_type
-                    derivation_path = ""
 
             elif index == 2:
                 if policy_type == TYPE_MINISCRIPT:
@@ -203,14 +203,14 @@ class WalletSettings(Page):
                 else:
                     new_script_type = self._script_type()
                 if new_script_type is not None:
-                    script_type = new_script_type
                     derivation_path = ""
+                    script_type = new_script_type
             elif index == 3:
                 if policy_type != TYPE_MINISCRIPT:
                     new_account = self._account(account)
                     if new_account is not None:
-                        account = new_account
                         derivation_path = ""
+                        account = new_account
                 else:
                     new_derivation_path = self._derivation_path(derivation_path)
                     if new_derivation_path is not None:

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -127,7 +127,7 @@ class WalletSettings(Page):
         policy_type = key.policy_type
         script_type = key.script_type
         account = key.account_index
-        custom_derivation = key.derivation if key.custom_derivation else None
+        derivation_path = key.derivation
         while True:
             wallet_info = network["name"] + "\n"
             # Find the policy type string from the POLICY_TYPE_IDS dictionary
@@ -138,13 +138,10 @@ class WalletSettings(Page):
                     break
             wallet_info += policy_type_str + "\n"
             wallet_info += str(script_type).upper() + "\n"
-            if policy_type != TYPE_MINISCRIPT or not custom_derivation:
+            if not derivation_path:
                 derivation_path = self._derivation_path_str(
                     policy_type, script_type, network, account
                 )
-                custom_derivation = ""
-            else:
-                derivation_path = custom_derivation
             wallet_info += DERIVATION_PATH_SYMBOL + " " + derivation_path
 
             self.ctx.display.clear()
@@ -177,6 +174,7 @@ class WalletSettings(Page):
                 new_network = self._coin_type()
                 if new_network is not None:
                     network = new_network
+                    derivation_path = ""
             elif index == 1:
                 new_policy_type = self._policy_type()
                 if new_policy_type is not None:
@@ -197,6 +195,7 @@ class WalletSettings(Page):
                         # If is miniscript, pick P2WSH or P2TR
                         script_type = self._miniscript_type()
                         script_type = P2WSH if script_type is None else script_type
+                    derivation_path = ""
 
             elif index == 2:
                 if policy_type == TYPE_MINISCRIPT:
@@ -205,15 +204,17 @@ class WalletSettings(Page):
                     new_script_type = self._script_type()
                 if new_script_type is not None:
                     script_type = new_script_type
+                    derivation_path = ""
             elif index == 3:
                 if policy_type != TYPE_MINISCRIPT:
                     new_account = self._account(account)
                     if new_account is not None:
                         account = new_account
+                        derivation_path = ""
                 else:
                     new_derivation_path = self._derivation_path(derivation_path)
                     if new_derivation_path is not None:
-                        custom_derivation = new_derivation_path
+                        derivation_path = new_derivation_path
         return network, policy_type, script_type, account, derivation_path
 
     def _coin_type(self):


### PR DESCRIPTION
### What is this PR for?
A minor issue found prior to release:
* If Key.policy is Miniscript, then custom_derivation was true, so it became sticky when customizing:
* became problematic if customizing for network between main/test w/o altering Policy... would not update derivation.

This pr changes key:
* no notion of "custom_derivation", derivation is like other customizable attributes, will be defaulted if initialized empty,

And wallet_settings.customize_wallet:
* any change of network, policy, script_type, account will unset current derivation, so that it gets re-defaulted
* if changing derivation (currently only for Miniscript) then it won't get re-defaulted.

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
