### PR TITLE
Hide menu New Mnemonic when hide_mnemonic enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog 25.XX.X - XXX 2025
+
+### New Mnemonic menu disabled by Hide Mnemonic
+When enabled, the hide mnemonic setting also disables the New Mnemonic menu
+
 # Changelog 25.03.0 - March 2025
 
 ### Taproot and WSH Miniscript support

--- a/src/boot.py
+++ b/src/boot.py
@@ -108,18 +108,18 @@ def login(ctx_login):
     """Loads and run the Login page"""
     from krux.pages.login import Login
 
-    login_start_from = None
+    start_from = None
     while True:
-        if not Login(ctx_login).run(login_start_from):
+        if not Login(ctx_login).run(start_from):
+            # Exited for shutdown
             break
 
         if ctx_login.wallet is not None:
-            # Have a loaded wallet
+            # Exited for Home menu
             break
-        # Login closed due to change of locale at Settings
-        login_start_from = (
-            Login.SETTINGS_MENU_INDEX
-        )  # will start Login again from Settings index
+
+        # Exited for change in Settings
+        start_from = Login.SETTINGS_MENU_INDEX
 
     # Unimport Login the free memory
     sys.modules.pop("krux.pages.login")

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -75,7 +75,14 @@ class Login(Page):
                 ctx,
                 [
                     (t("Load Mnemonic"), self.load_key),
-                    (t("New Mnemonic"), self.new_key),
+                    (
+                        t("New Mnemonic"),
+                        (
+                            self.new_key
+                            if not Settings().security.hide_mnemonic
+                            else None
+                        ),
+                    ),
                     (t("Settings"), self.settings),
                     (t("Tools"), self.tools),
                     (t("About"), self.about),


### PR DESCRIPTION
### What is this PR for?
The Hide Mnemonic settings will hide any BIP39 mnemonics, even newly created ones. So there is no point in enabling the New Mnemonic menu because the user will not see the mnemonic if hide is enabled.

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
