### PR TITLE
Coverage 100% of src/krux/pages/new_mnemonic/dice_rolls.py

### DIFF
--- a/tests/pages/new_mnemonic/test_dice_rolls.py
+++ b/tests/pages/new_mnemonic/test_dice_rolls.py
@@ -75,6 +75,53 @@ GOOD_ROLLS_SEQUENCE = [
 ]
 
 
+def test_entropy_but_not_proceed(m5stickv, mocker):
+    """
+    Test a situation where the user begin the creation of an entropy on m5stickv but, in the middle
+    time, stop the procedure (when krux ask "proceed" and the user choose "No")
+    """
+    from krux.pages.new_mnemonic.dice_rolls import DiceEntropy
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = (
+        # 1 press to proceed to 12 words
+        [BUTTON_ENTER]
+        +
+        # 1 press to cancel the proceed
+        [BUTTON_PAGE_PREV]
+    )
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    dice_entropy = DiceEntropy(ctx)
+    entropy = dice_entropy.new_key()
+
+    assert entropy is None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
+def test_entropy_on_amigo_device_but_not_proceed(amigo, mocker):
+    """
+    Test a situation where the user begin the creation of an entropy in Amigo but, in the
+    middle time, stop the procedure (when krux ask "proceed" and the user choose "No")
+    """
+    from krux.pages.new_mnemonic.dice_rolls import DiceEntropy
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = (
+        # 1 press to proceed to 12 words
+        [BUTTON_ENTER]
+        +
+        # 1 press to cancel the proceed and then confirm the cancelation
+        [BUTTON_PAGE, BUTTON_ENTER]
+    )
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    dice_entropy = DiceEntropy(ctx)
+    entropy = dice_entropy.new_key()
+
+    assert entropy is None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
 def test_new_12w_from_d6(m5stickv, mocker):
     from krux.pages.new_mnemonic.dice_rolls import DiceEntropy, D6_12W_MIN_ROLLS
     from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV


### PR DESCRIPTION
### What is this PR for?

This commit aim to target 100% on dice_rolls.py page by adding two tests, with same situation, in two different devices:

* The user begin the creation of an entropy in m5stickv but, in middle time, stop the procedure (when krux ask "proceed" and the user choose "No");

* The user begin the creation of an entropy in Amigo, but in middle time, stop the procedure (when krux ask "proceed" and the user choose "No).

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
