### PR TITLE
Removed deadcode verification

### DIFF
--- a/src/krux/bbqr.py
+++ b/src/krux/bbqr.py
@@ -188,13 +188,6 @@ def base32_decode_stream(encoded_str):
             decoded_bytes.append((buffer >> bits_left) & 0xFF)
             buffer &= (1 << bits_left) - 1  # Keep only the remaining bits
 
-    # Process any remaining bits if they form a valid byte
-    if 0 < bits_left < 8:
-        remaining_byte = (buffer << (8 - bits_left)) & 0xFF
-        if remaining_byte != 0:
-            # Dead code? remaining bits seem to always be padding (null)
-            decoded_bytes.append(remaining_byte)
-
     return bytes(decoded_bytes)
 
 


### PR DESCRIPTION
### What is this PR for?

Fix #547 

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: code remotion that is unreachable

### Details

This commit remove the checking of remaining bytes in Rfc4648 implementation of krux/src/bbqr.py::base32_decode_stream function.

* The implementation appear to be well coded and as the condition seems to be logically unreachable;

* the base_decode_stream passed by some diff fuzz tests and appear to not have any issues, attesting to the correctness of the implementation.

