### PR TITLE
Cover 100% of test_bip39.py

### DIFF
--- a/tests/test_bip39.py
+++ b/tests/test_bip39.py
@@ -1,8 +1,10 @@
-from krux import bip39 as kruxbip39
+import secrets
+
+import pytest
 from embit import bip39
 from embit.wordlists.bip39 import WORDLIST
-import secrets
-import pytest
+
+from krux import bip39 as kruxbip39
 
 
 def test_one_word_mnemonics():
@@ -57,6 +59,21 @@ def test_random_cases_custom_wordlist():
             assert (
                 kruxbip39.k_mnemonic_bytes(
                     bip39.mnemonic_from_bytes(token_bytes), wordlist=wordlist
+                )
+                == token_bytes
+            )
+
+
+def test_random_cases_custom_wordlist_without_checksum():
+    wordlist = tuple(kruxbip39.WORDLIST)
+    for _ in range(200):
+        for size in (16, 20, 24, 28, 32):
+            token_bytes = secrets.token_bytes(size)
+            assert (
+                kruxbip39.k_mnemonic_bytes(
+                    bip39.mnemonic_from_bytes(token_bytes),
+                    wordlist=wordlist,
+                    ignore_checksum=True,
                 )
                 == token_bytes
             )


### PR DESCRIPTION
### What is this PR for?

The test_bip39.py was ignoring the case where the k_mnemonic_bytes could be called with ignore_checksum = True.

This commit just add this situation.

It's worth to mention that i tested with many bip39 vectors with [krux-fuzz](https://github.com/qlrd/krux-fuzz/blob/main/fuzz/fuzz_targets/diff_bip39.rs)

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: coverage
