### PR TITLE
Fix false positive call on mocking is_on method

### DIFF
--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -99,11 +99,11 @@ def test_toggle_on_wonder_mv(mocker, wonder_mv):
     mocker.spy(light, "turn_on")
 
     # Toggle from on
-    mocker.patch.object(light, "is_on", new=lambda: True)
+    mocker.patch.object(light.circuit, "value", return_value=1)
     light.toggle()
     light.turn_off.assert_called()
 
     # Toggle again, now from off
-    mocker.patch.object(light, "is_on", new=lambda: False)
+    mocker.patch.object(light.circuit, "value", return_value=0)
     light.toggle()
     light.turn_on.assert_called()


### PR DESCRIPTION
### What is this PR for?

Fix #553

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: coverage

### Context

Previsouly, the `tests/test_light.py` was patching the is_on method and the real method is never executed, and thus the test pass but not hit the tested code.

This is classic situation where what we want to mock isnt the thing, but the dependencies of the thing (in this case, what is beign called inside what we want to test).

Instead mock the is_on method, is necessary to mock the `IOCircuit::circuit.value()` call (that is really what we want to test).

This commit changes the toggles in mocker from `ligth.is_on` to `light.circuit.value`.

