### PR TITLE
Added fingerprint preview when changing wallet passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Addresses are displayed in groups of 4, separated by spaces, for better readabil
 ### Other Bug Fixes and Optimizations
 - Fix printing words instead of numbers when using "Backup Mnemonic > Other formats > Numbers".
 - Added fingerprint to mnemonic preview and editor.
+- Show fingerprint preview when changing wallet passphrase.
 - Store encrypted mnemonic now asks if you want to use the fingerprint as ID.
 - Optimized the way we check device's board values.
 - Added QR Code to About screen.

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -99,7 +99,9 @@ class Home(Page):
         from ...wallet import Wallet
 
         passphrase_editor = PassphraseEditor(self.ctx)
-        passphrase = passphrase_editor.load_passphrase_menu()
+        passphrase = passphrase_editor.load_passphrase_menu(
+            self.ctx.wallet.key.mnemonic
+        )
         if passphrase is None:
             return MENU_CONTINUE
 

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -366,7 +366,7 @@ class Login(Page):
                 from .wallet_settings import PassphraseEditor
 
                 passphrase_editor = PassphraseEditor(self.ctx)
-                temp_passphrase = passphrase_editor.load_passphrase_menu()
+                temp_passphrase = passphrase_editor.load_passphrase_menu(mnemonic)
                 if temp_passphrase is not None:
                     passphrase = temp_passphrase
             elif index == 2:

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -68,7 +68,7 @@ class PassphraseEditor(Page):
         super().__init__(ctx, None)
         self.ctx = ctx
 
-    def load_passphrase_menu(self):
+    def load_passphrase_menu(self, mnemonic):
         """Load a passphrase from keypad or QR code"""
         passphrase = ""
         while True:
@@ -85,13 +85,20 @@ class PassphraseEditor(Page):
                 return None
 
             from ..themes import theme
+            from ..key import Key
 
             self.ctx.display.clear()
             self.ctx.display.draw_hcentered_text(
-                passphrase, offset_y=DEFAULT_PADDING + FONT_HEIGHT
+                Key.extract_fingerprint(mnemonic, passphrase),
+                color=theme.highlight_color,
             )
             self.ctx.display.draw_hcentered_text(
-                t("Passphrase") + ":", color=theme.highlight_color
+                t("Passphrase") + ":",
+                DEFAULT_PADDING + FONT_HEIGHT * 2,
+                theme.highlight_color,
+            )
+            self.ctx.display.draw_hcentered_text(
+                passphrase, DEFAULT_PADDING + FONT_HEIGHT * 3
             )
             if self.prompt(
                 t("Proceed?"),

--- a/tests/pages/test_wallet_settings.py
+++ b/tests/pages/test_wallet_settings.py
@@ -31,7 +31,7 @@ def test_type_passphrase_esc(m5stickv, mocker):
     ]
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     passphrase_editor = PassphraseEditor(ctx)
-    test_passphrase = passphrase_editor.load_passphrase_menu()
+    test_passphrase = passphrase_editor.load_passphrase_menu(ctx.key.mnemonic)
 
     assert test_passphrase is None
 


### PR DESCRIPTION
### What is this PR for?
- Now when Loading a wallet or changing a loaded wallet passphrase it will preview the wallet's fingerprint for confirmation.


### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [x] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
