### PR TITLE
simulator redraws screen when app regains focus

### DIFF
--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -273,6 +273,8 @@ try:
                     buttons.buttons_control.page_prev_event_flag = True
             if event.type == pg.MOUSEBUTTONDOWN:
                 ft6x36.touch_control.trigger_event()
+            if event.type == pg.ACTIVEEVENT and event.gain:
+                pg.display.flip()
 
 except KeyboardInterrupt:
     shutdown()


### PR DESCRIPTION
### What is this PR for?

I tend to move windows around while scanning qr's and if any window glides over the simulator I lose whatever was on it until I can find something to click on.  An event WINDOWEXPOSE happens whenever an external window causes a problem but this pr is not checking for that, rather, whenever the simulator window gains focus, by keyboard,  minimize/restore or even the mouse entering the app real-estate, the screen will be redrawn w/o using update_screen(). 

### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other (simulator only)
