### PR TITLE
Covered 100% src/krux/printers/__init__.py

### DIFF
--- a/src/krux/printers/__init__.py
+++ b/src/krux/printers/__init__.py
@@ -19,10 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from ..krux_settings import t
-
-# from ..settings import CategorySetting, SettingsNamespace
-from ..krux_settings import Settings, PrinterSettings
+from ..krux_settings import PrinterSettings, Settings
 
 
 class Printer:

--- a/tests/printers/test_printer.py
+++ b/tests/printers/test_printer.py
@@ -38,3 +38,48 @@ def test_print_qr_code_fails(mocker, m5stickv, bad_printer_cls):
 
     with pytest.raises(NotImplementedError):
         printer.print_qr_code("")
+
+
+def test_print_string_fails(mocker, m5stickv, bad_printer_cls):
+    printer = bad_printer_cls()
+    with pytest.raises(NotImplementedError):
+        printer.print_string("")
+
+
+def test_create_printer_none_driver(mocker, m5stickv):
+    from krux.krux_settings import Settings
+    from krux.printers import create_printer
+
+    Settings().hardware.printer.driver = "none"
+    printer = create_printer()
+    assert printer is None
+
+
+def test_create_printer_adafruit_driver(mocker, m5stickv):
+    from krux.krux_settings import Settings
+    from krux.printers import create_printer
+
+    Settings().hardware.printer.driver = "thermal/adafruit"
+    printer = create_printer()
+    assert printer is not None
+    assert printer.__class__.__name__ == "AdafruitPrinter"
+
+
+def test_create_printer_fileprinter_driver(mocker, m5stickv):
+    from krux.krux_settings import Settings
+    from krux.printers import create_printer
+
+    Settings().hardware.printer.driver = "cnc/file"
+    printer = create_printer()
+    assert printer is not None
+    assert printer.__class__.__name__ == "FilePrinter"
+
+
+def test_create_grbl_driver(mocker, m5stickv):
+    from krux.krux_settings import Settings
+    from krux.printers import create_printer
+
+    Settings().hardware.printer.driver = "cnc/grbl"
+    printer = create_printer()
+    assert printer is not None
+    assert printer.__class__.__name__ == "GRBLPrinter"


### PR DESCRIPTION
### What is this PR for?

* lint: removed unused `t` function, removed line with import commented
and sorted the imports by aphabetical order;

* tests: added test cases for create_printer function (none, thermal/adafruit,
cnc/file and cnc/grbl).

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: improvement of tests.
