### PR TITLE
Remove deadcode in src/pages/menomic_editor.py

### DIFF
--- a/src/krux/pages/mnemonic_editor.py
+++ b/src/krux/pages/mnemonic_editor.py
@@ -86,8 +86,6 @@ class MnemonicEditor(Page):
             wordlist = WORDLIST
         if len(prefix) > 0:
             letter = prefix[0]
-            if letter not in self.search_ranges:
-                return None
             start, stop = self.search_ranges[letter]
             matching_words = list(
                 filter(
@@ -109,8 +107,6 @@ class MnemonicEditor(Page):
         if len(prefix) == 0:
             return self.search_ranges.keys()
         letter = prefix[0]
-        if letter not in self.search_ranges:
-            return ""
         start, stop = self.search_ranges[letter]
         return {
             word[len(prefix)]


### PR DESCRIPTION
### What is this PR for?

Fix #568

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: remotion of possible deadcode.

### Details

The `alt_wordlist` parameter in `MnemonicEditor` methods such as `compute_search_ranges()`, `autocomplete()` , and `possible_letters()`  is only meaningfully used in one specific case: when editing the final word of a new mnemonic.

In all other interactive flows (`edit()` , `edit_word()`), it is ignored, making calls such `if letter not in self.search_ranges` in line 90 and 113 effectively dead — unless forcefully tested with patched inputs.

The virtual keyboard only presents valid next letters (from `possible_letters()`), which ensures users cannot enter a letter outside the search_ranges. This makes the above line nearly impossible to hit during interactive usage — only patching tests with manual overrides can trigger it.

This commit remove the calls on these checks.