### PR TITLE
Coeverage 100% src/krux/sdcard.py

### DIFF
--- a/tests/test_sd_card.py
+++ b/tests/test_sd_card.py
@@ -11,6 +11,22 @@ def mocker_sd_card_ok(mocker):
     mocker.patch("os.remove", mocker.mock_open(read_data=""))
 
 
+@pytest.fixture
+def mocker_sd_card_dir_exist(mocker):
+    mocker.patch(
+        "os.stat",
+        new=mocker.MagicMock(return_value=(0x4000,)),
+    )
+
+
+@pytest.fixture
+def mocker_sd_card_dir_not_exist(mocker):
+    mocker.patch(
+        "os.listdir",
+        new=mocker.MagicMock(side_effect=OSError("SDCard not found")),
+    )
+
+
 def test_sd_read_without_mock(m5stickv):
     import machine
     from krux.sd_card import SDHandler
@@ -43,3 +59,15 @@ def test_sd_read_with_mock(m5stickv, mocker_sd_card_ok):
 
     machine.SDCard.remount.assert_called()
     assert ex == False  # runned with mock, everything fine!
+
+
+def test_sd_card_dir_exists(m5stickv, mocker_sd_card_dir_exist):
+    from krux.sd_card import SDHandler
+
+    assert SDHandler.dir_exists("adir")
+
+
+def test_sd_card_dir_not_exists(m5stickv, mocker_sd_card_dir_not_exist):
+    from krux.sd_card import SDHandler
+
+    assert not SDHandler.dir_exists("adir")


### PR DESCRIPTION
### What is this PR for?

* added two fixtures to mock `os.stat`, so it can prepare the static method `SDHandler.dir_exists` to return  `True` or `False`;

* added two tests to cover the S`DHandler.dir_exists` cases (`True` or `False`).

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: coverage 100% of `src/krux/sdcard.py`
