### PR TITLE
Cover 100% src/krux/settings.py

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,20 @@
 # Tests for krux.settings
 
 
+def test_setting_get_method_return_self_when_obj_is_none(mocker, m5stickv):
+    from krux.settings import Setting
+
+    # this will test __get__ method
+    # of Setting class. When the given
+    # object is None, it must return
+    # the same instance of Setting.
+    s = Setting("krux_has_no_owner", "default")
+    result = s.__get__(None)
+
+    assert isinstance(result, Setting)
+    assert result is s
+
+
 def test_init(mocker, m5stickv):
     from krux.krux_settings import Settings, SettingsNamespace
     import pytest


### PR DESCRIPTION
### What is this PR for?

* The `__get__` method of `Setting` class wasn't being covered when the parameter `obj` is `None`;

* added a test case to cover the above mentioned situation: created a simple instance of `Setting` class and call its `__get__` method with a parameter `None`, expecting that the return value is the instance itself.

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [x] Yes

### In which device you built?
- [ ] M5stickV
- [X] Amigo: `b8a6df3ae2c21b78ddca907fb9a8344797716feea67b0bf7d737122854c3f87a`
- [ ] Bit
- [ ] Docker
- [ ] Cube
- [ ] Yahboom
- [ ] WonderMV

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: coverage
