### PR TITLE
Tools > Print Test QR asks before printing..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Addresses are displayed in groups of 4, separated by spaces, for better readabil
 
 ### Other Bug Fixes and Optimizations
 - Fix printing words instead of numbers when using "Backup Mnemonic > Other formats > Numbers".
+- "Tools > Print Test QR" asks user before printing.
 - Added fingerprint to mnemonic preview and editor.
 - Show fingerprint preview when changing wallet passphrase.
 - Store encrypted mnemonic now asks if you want to use the fingerprint as ID.

--- a/simulator/kruxsim/mocks/machine.py
+++ b/simulator/kruxsim/mocks/machine.py
@@ -33,13 +33,13 @@ old_create_printer = create_printer
 
 def new_create_printer():
     printer = old_create_printer()
-    old_print_qr_code = printer.print_qr_code
-
-    def new_print_qr_code(qr_code):
-        print("QR Code sent to printer:", qr_code)
-        return old_print_qr_code(qr_code)
-
-    printer.print_qr_code = new_print_qr_code
+    if printer:
+        def new_print_qr_code(qr_code):
+            print("QR Code sent to printer:", qr_code)
+            return old_print_qr_code(qr_code)
+        
+        old_print_qr_code = printer.print_qr_code
+        printer.print_qr_code = new_print_qr_code
     return printer
 
 

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -371,11 +371,11 @@ class Page:
                         word,
                     )
 
-    def print_prompt(self, text):
+    def print_prompt(self, text, check_printer=True):
         """Prompts the user to print a QR code in the specified format
         if a printer is connected
         """
-        if not self.has_printer():
+        if not self.has_printer() and check_printer:
             return False
         self.ctx.display.clear()
         prompt_text = (text + "\n\n%s\n\n") % Settings().hardware.printer.driver

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -47,7 +47,7 @@ from ..display import (
     STATUS_BAR_HEIGHT,
     BOTTOM_LINE,
 )
-from ..qr import to_qr_codes
+from ..qr import to_qr_codes, FORMAT_NONE
 from ..krux_settings import t, Settings
 from ..sd_card import SDHandler
 from ..kboard import kboard
@@ -228,7 +228,9 @@ class Page:
         if not buffer_title:
             self.ctx.display.draw_hcentered_text(buffer, offset_y)
 
-    def display_qr_codes(self, data, qr_format, title="", highlight_prefix=""):
+    def display_qr_codes(
+        self, data, qr_format=FORMAT_NONE, title="", highlight_prefix=""
+    ):
         """Displays a QR code or an animated series of QR codes to the user, encoding them
         in the specified format
         """

--- a/src/krux/pages/home_pages/mnemonic_backup.py
+++ b/src/krux/pages/home_pages/mnemonic_backup.py
@@ -21,7 +21,6 @@
 # THE SOFTWARE.
 
 from ...display import FONT_HEIGHT, SMALLEST_HEIGHT
-from ...qr import FORMAT_NONE
 from ...krux_settings import t, Settings, THERMAL_ADAFRUIT_TXT
 from .. import (
     Page,
@@ -158,12 +157,12 @@ class MnemonicsView(Page):
         """Displays regular words QR code"""
         title = t("Plaintext QR")
         data = self.ctx.wallet.key.mnemonic
-        self.display_qr_codes(data, FORMAT_NONE, title)
+        self.display_qr_codes(data, title=title)
 
         from ..utils import Utils
 
         utils = Utils(self.ctx)
-        utils.print_standard_qr(data, FORMAT_NONE, title)
+        utils.print_standard_qr(data, title=title)
         return MENU_CONTINUE
 
     def display_seed_qr(self, binary=False):

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -36,7 +36,6 @@ from ..format import generate_thousands_separator
 from ..sd_card import SDHandler
 from ..display import BOTTOM_PROMPT_LINE
 from ..krux_settings import t
-from ..qr import FORMAT_NONE
 
 
 class Tools(Page):
@@ -125,11 +124,12 @@ class Tools(Page):
     def print_test(self):
         """Handler for the 'Print Test QR' menu item"""
         title = t("Krux Printer Test QR")
-        self.display_qr_codes(title, FORMAT_NONE, title)
-        from .print_page import PrintPage
+        self.display_qr_codes(title, title=title)
 
-        print_page = PrintPage(self.ctx)
-        print_page.print_qr(title, title=title)
+        from .utils import Utils
+
+        utils = Utils(self.ctx)
+        utils.print_standard_qr(title, title=title)
         return MENU_CONTINUE
 
     def create_qr(self):

--- a/src/krux/pages/tools.py
+++ b/src/krux/pages/tools.py
@@ -129,7 +129,7 @@ class Tools(Page):
         from .utils import Utils
 
         utils = Utils(self.ctx)
-        utils.print_standard_qr(title, title=title)
+        utils.print_standard_qr(title, title=title, check_printer=False)
         return MENU_CONTINUE
 
     def create_qr(self):

--- a/src/krux/pages/utils.py
+++ b/src/krux/pages/utils.py
@@ -42,11 +42,17 @@ class Utils(Page):
         super().__init__(ctx, None)
 
     def print_standard_qr(
-        self, data, qr_format=FORMAT_NONE, title="", width=33, is_qr=False
+        self,
+        data,
+        qr_format=FORMAT_NONE,
+        title="",
+        width=33,
+        is_qr=False,
+        check_printer=True,
     ):
         """Loads printer driver and UI"""
         # Only loads printer related modules if needed
-        if self.print_prompt(t("Print as QR?")):
+        if self.print_prompt(t("Print as QR?"), check_printer):
             from .print_page import PrintPage
 
             print_page = PrintPage(self.ctx)

--- a/src/krux/pages/utils.py
+++ b/src/krux/pages/utils.py
@@ -24,6 +24,7 @@ from . import Page
 from ..krux_settings import t
 from ..sd_card import SDHandler
 from embit.wordlists.bip39 import WORDLIST
+from ..qr import FORMAT_NONE
 
 
 class Utils(Page):
@@ -40,7 +41,9 @@ class Utils(Page):
     def __init__(self, ctx):
         super().__init__(ctx, None)
 
-    def print_standard_qr(self, data, qr_format=None, title="", width=33, is_qr=False):
+    def print_standard_qr(
+        self, data, qr_format=FORMAT_NONE, title="", width=33, is_qr=False
+    ):
         """Loads printer driver and UI"""
         # Only loads printer related modules if needed
         if self.print_prompt(t("Print as QR?")):

--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -24,7 +24,7 @@ from embit.descriptor.arguments import Key
 from embit.networks import NETWORKS
 from embit.bip32 import HARDENED_INDEX
 from .krux_settings import t
-from .qr import FORMAT_BBQR
+from .qr import FORMAT_BBQR, FORMAT_NONE
 from .key import (
     P2PKH,
     P2SH_P2WPKH,
@@ -49,7 +49,7 @@ class Wallet:
     def __init__(self, key):
         self.key = key
         self.wallet_data = None
-        self.wallet_qr_format = None
+        self.wallet_qr_format = FORMAT_NONE
         self.descriptor = None
         self.label = None
         self.policy = None

--- a/tests/pages/home_pages/test_mnemonic_backup.py
+++ b/tests/pages/home_pages/test_mnemonic_backup.py
@@ -199,7 +199,7 @@ def test_mnemonic_standard_qr(mocker, m5stickv, tdata):
 
         title = "Plaintext QR"
         mnemonics.display_qr_codes.assert_called_with(
-            ctx.wallet.key.mnemonic, FORMAT_NONE, title
+            ctx.wallet.key.mnemonic, title=title
         )
         assert ctx.input.wait_for_button.call_count == len(case[2])
 
@@ -453,7 +453,7 @@ def test_mnemonic_standard_qr_touch(mocker, amigo, tdata):
 
         title = "Plaintext QR"
         mnemonics.display_qr_codes.assert_called_with(
-            ctx.wallet.key.mnemonic, FORMAT_NONE, title
+            ctx.wallet.key.mnemonic, title=title
         )
 
         assert ctx.input.wait_for_button.call_count == len(case[2])

--- a/tests/pages/test_tools.py
+++ b/tests/pages/test_tools.py
@@ -151,7 +151,7 @@ def test_printer_test_tool(amigo, mocker):
         test_tools.print_test()
 
         mocked_print_qr.assert_called_with(
-            "Krux Printer Test QR", title="Krux Printer Test QR"
+            "Krux Printer Test QR", title="Krux Printer Test QR", check_printer=False
         )
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 

--- a/tests/pages/test_tools.py
+++ b/tests/pages/test_tools.py
@@ -145,7 +145,7 @@ def test_printer_test_tool(amigo, mocker):
 
     BTN_SEQUENCE = [BUTTON_ENTER]  # Confirm print, then leave
 
-    with patch("krux.pages.print_page.PrintPage.print_qr") as mocked_print_qr:
+    with patch("krux.pages.utils.Utils.print_standard_qr") as mocked_print_qr:
         ctx = create_ctx(mocker, BTN_SEQUENCE)
         test_tools = Tools(ctx)
         test_tools.print_test()


### PR DESCRIPTION
### What is this PR for?
- User prompted before printing test QR code.
- Small code optimizations/fixes regarding `qr_format` initialization (Ex: `Utils.print_standard_qr("Some data")` would raise an exception because qr_format was initialized with `None`).


### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, Yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
