### PR TITLE
Fix about screen QR code for cube

### DIFF
--- a/simulator/kruxsim/mocks/lcd.py
+++ b/simulator/kruxsim/mocks/lcd.py
@@ -332,34 +332,8 @@ def draw_string(x, y, s, color, bgcolor=COLOR_BLACK):
     pg.event.post(pg.event.Event(events.LCD_DRAW_STRING_EVENT, {"f": run}))
 
 
-def draw_qr_code(offset_y, code_str, max_width, dark_color, light_color, background):
-
-    def run():
-        starting_size = 0
-        while code_str[starting_size] != "\n":
-            starting_size += 1
-        scale = max_width // starting_size
-        qr_width = starting_size * scale
-        offset = (max_width - qr_width) // 2
-        for og_y in range(starting_size):
-            for i in range(scale):
-                y = og_y * scale + i
-                for og_x in range(starting_size):
-                    for j in range(scale):
-                        x = og_x * scale + j
-                        og_yx_index = og_y * (starting_size + 1) + og_x
-                        screen.set_at(
-                            (offset + x, offset + offset_y + y),
-                            dark_color if code_str[og_yx_index] == "1" else light_color,
-                        )
-
-    dark_color = rgb565torgb888(dark_color)
-    light_color = rgb565torgb888(light_color)
-    pg.event.post(pg.event.Event(events.LCD_DRAW_QR_CODE_EVENT, {"f": run}))
-
-
 def draw_qr_code_binary(
-    offset_y, code_bin, max_width, dark_color, light_color, background
+    offset_x, offset_y, code_bin, max_width, dark_color, light_color, background
 ):
 
     def run():
@@ -373,22 +347,22 @@ def draw_qr_code_binary(
         # Top border
         for rx in range(max_width):
             for ry in range(border_size):
-                screen.set_at((rx, ry), light_color)
+                screen.set_at((rx + offset_x, ry + offset_y), light_color)
 
         # Bottom border
         for rx in range(max_width):
             for ry in range(opposite_border_offset, max_width):
-                screen.set_at((rx, ry), light_color)
+                screen.set_at((rx + offset_x, ry + offset_y), light_color)
 
         # Left border
         for rx in range(border_size):
             for ry in range(border_size, opposite_border_offset):
-                screen.set_at((rx, ry), light_color)
+                screen.set_at((rx + offset_x, ry + offset_y), light_color)
 
         # Right border
         for rx in range(opposite_border_offset, max_width):
             for ry in range(border_size, opposite_border_offset):
-                screen.set_at((rx, ry), light_color)
+                screen.set_at((rx + offset_x, ry + offset_y), light_color)
         # QR code rendering
         for og_y in range(starting_size):
             for og_x in range(starting_size):
@@ -400,7 +374,7 @@ def draw_qr_code_binary(
                     y = border_size + og_y * scale + i
                     for j in range(scale):
                         x = border_size + og_x * scale + j
-                        screen.set_at((x, y), color)
+                        screen.set_at((x + offset_x, y + offset_y), color)
 
     dark_color = rgb565torgb888(dark_color)
     light_color = rgb565torgb888(light_color)
@@ -496,7 +470,6 @@ if "lcd" not in sys.modules:
         height=height,
         string_width_px=string_width_px,
         draw_string=draw_string,
-        draw_qr_code=draw_qr_code,
         draw_qr_code_binary=draw_qr_code_binary,
         fill_rectangle=fill_rectangle,
         draw_circle=draw_circle,

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -188,11 +188,13 @@ class Display:
         pwm_value *= 20
         self.blk_ctrl.duty(pwm_value)
 
-    def qr_offset(self):
+    def qr_offset(self, qr_offset=0):
         """Retuns y offset to subtitle QR codes"""
-        if kboard.is_cube:
-            return BOTTOM_LINE
-        return self.width() + MINIMAL_PADDING
+        if qr_offset == 0:
+            if kboard.is_cube:
+                return BOTTOM_LINE
+            return self.width() + MINIMAL_PADDING
+        return qr_offset + MINIMAL_PADDING
 
     def width(self):
         """Returns the width of the display, taking into account rotation"""
@@ -472,11 +474,18 @@ class Display:
         self.clear()
 
     def draw_qr_code(
-        self, offset_y, qr_code, dark_color=QR_DARK_COLOR, light_color=QR_LIGHT_COLOR
+        self,
+        qr_code,
+        offset_x=0,
+        offset_y=0,
+        width=0,
+        dark_color=QR_DARK_COLOR,
+        light_color=QR_LIGHT_COLOR,
     ):
         """Draws a QR code on the screen"""
+        width = self.width() if width == 0 else width
         lcd.draw_qr_code_binary(
-            offset_y, qr_code, self.width(), dark_color, light_color, light_color
+            offset_x, offset_y, qr_code, width, dark_color, light_color, light_color
         )
 
     def set_pmu_backlight(self, level):

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -188,13 +188,13 @@ class Display:
         pwm_value *= 20
         self.blk_ctrl.duty(pwm_value)
 
-    def qr_offset(self, qr_offset=0):
+    def qr_offset(self, y_offset=0):
         """Retuns y offset to subtitle QR codes"""
-        if qr_offset == 0:
+        if y_offset == 0:
             if kboard.is_cube:
                 return BOTTOM_LINE
             return self.width() + MINIMAL_PADDING
-        return qr_offset + MINIMAL_PADDING
+        return y_offset + MINIMAL_PADDING
 
     def width(self):
         """Returns the width of the display, taking into account rotation"""

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -229,19 +229,24 @@ class Page:
             self.ctx.display.draw_hcentered_text(buffer, offset_y)
 
     def display_qr_codes(
-        self, data, qr_format=FORMAT_NONE, title="", highlight_prefix=""
+        self,
+        data,
+        qr_format=FORMAT_NONE,
+        title="",
+        offset_x=0,
+        offset_y=0,
+        width=0,
+        highlight_prefix="",
     ):
         """Displays a QR code or an animated series of QR codes to the user, encoding them
         in the specified format
         """
-        done = False
-        i = 0
 
         # Precompute display-related values
         display_width = self.ctx.display.width()
         display_height = self.ctx.display.height()
-        is_portrait = display_height > display_width
-        qr_offset_val = self.ctx.display.qr_offset()
+        is_portrait = width != 0 or display_height > display_width
+        qr_offset_val = self.ctx.display.qr_offset(offset_y + width)
         qr_data_width = self.ctx.display.qr_data_width()
 
         self.ctx.display.clear()
@@ -273,20 +278,22 @@ class Page:
         code = None
         num_parts = 0
         btn = None
+        i = 0
+        done = False
         while not done:
             try:
                 code, num_parts = next(code_generator)
             except:
-                code_generator = to_qr_codes(
-                    data, self.ctx.display.qr_data_width(), qr_format
-                )
+                code_generator = to_qr_codes(data, qr_data_width, qr_format)
                 code, num_parts = next(code_generator)
 
             # Draw QR code
             if qr_foreground:
-                self.ctx.display.draw_qr_code(0, code, light_color=qr_foreground)
+                self.ctx.display.draw_qr_code(
+                    code, offset_x, offset_y, width, light_color=qr_foreground
+                )
             else:
-                self.ctx.display.draw_qr_code(0, code)
+                self.ctx.display.draw_qr_code(code, offset_x, offset_y, width)
 
             # Handle subtitle
             if subtitle_template and is_portrait:

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -818,6 +818,7 @@ class Login(Page):
         """Handler for the 'about' menu item"""
 
         import board
+        from ..kboard import kboard
         from ..metadata import VERSION
         from ..qr import FORMAT_NONE
 
@@ -830,5 +831,17 @@ class Login(Page):
             + t("Version")
             + ": %s" % VERSION
         )
-        self.display_qr_codes(title, FORMAT_NONE, msg, highlight_prefix=":")
+        offset_x = 0
+        width = 0
+        if kboard.is_cube:
+            offset_x = self.ctx.display.width() // 4
+            width = self.ctx.display.width() // 2
+        self.display_qr_codes(
+            title,
+            FORMAT_NONE,
+            msg,
+            offset_x=offset_x,
+            width=width,
+            highlight_prefix=":",
+        )
         return MENU_CONTINUE

--- a/src/krux/pages/qr_view.py
+++ b/src/krux/pages/qr_view.py
@@ -158,15 +158,11 @@ class SeedQRView(Page):
         grid_offset += grid_pad
         if mode == STANDARD_MODE:
             if self.qr_foreground:
-                self.ctx.display.draw_qr_code(
-                    0, self.code, light_color=self.qr_foreground
-                )
+                self.ctx.display.draw_qr_code(self.code, light_color=self.qr_foreground)
             else:
-                self.ctx.display.draw_qr_code(0, self.code)
+                self.ctx.display.draw_qr_code(self.code)
         elif mode == LINE_MODE:
-            self.ctx.display.draw_qr_code(
-                0, self.code, light_color=theme.disabled_color
-            )
+            self.ctx.display.draw_qr_code(self.code, light_color=theme.disabled_color)
             self.highlight_qr_region(
                 self.code, region=(0, self.lr_index, self.qr_size, 1)
             )
@@ -231,9 +227,7 @@ class SeedQRView(Page):
         elif mode == REGION_MODE:
             row = self.lr_index // self.columns
             column = self.lr_index % self.columns
-            self.ctx.display.draw_qr_code(
-                0, self.code, light_color=theme.disabled_color
-            )
+            self.ctx.display.draw_qr_code(self.code, light_color=theme.disabled_color)
             self.highlight_qr_region(
                 self.code,
                 region=(
@@ -280,7 +274,7 @@ class SeedQRView(Page):
                 )
             self._region_legend(row, column)
         else:  #  TRANSCRIBE_MODE
-            self.ctx.display.draw_qr_code(0, self.code, light_color=WHITE)
+            self.ctx.display.draw_qr_code(self.code, light_color=WHITE)
             for i in range(self.qr_size + 1):
                 self.ctx.display.fill_rectangle(
                     grid_offset,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from .shared_mocks import (
     board_cube,
     board_m5stickv,
     board_wonder_mv,
+    board_yahboom,
     encode_to_string,
     encode,
     statvfs,
@@ -109,6 +110,14 @@ def cube(monkeypatch, mp_modules):
 
 
 @pytest.fixture
+def yahboom(monkeypatch, mp_modules):
+    import sys
+
+    monkeypatch.setitem(sys.modules, "board", board_yahboom())
+    reset_krux_modules()
+
+
+@pytest.fixture
 def wonder_mv(monkeypatch, mp_modules):
     import sys
 
@@ -116,6 +125,6 @@ def wonder_mv(monkeypatch, mp_modules):
     reset_krux_modules()
 
 
-@pytest.fixture(params=["amigo", "m5stickv", "dock", "cube"])
+@pytest.fixture(params=["amigo", "m5stickv", "dock", "cube", "yahboom", "wonder_mv"])
 def multiple_devices(request):
     return request.getfixturevalue(request.param)

--- a/tests/pages/test_flash_tools.py
+++ b/tests/pages/test_flash_tools.py
@@ -79,17 +79,24 @@ def test_tc_flash_hash(multiple_devices, mocker):
 
     BTN_SEQUENCE = [BUTTON_ENTER]
 
+    DOCK_FW_POS = 228
+    DOCK_USER_POS = 244
+
     fw_words_positions = {
         "amigo": 307,
         "m5stickv": 147,
-        "dock": 228,
+        "dock": DOCK_FW_POS,
         "cube": 208,
+        "yahboom": DOCK_FW_POS,
+        "wonder_mv": DOCK_FW_POS,
     }
     users_data_words_positions = {
         "amigo": 331,
         "m5stickv": 161,
-        "dock": 244,
+        "dock": DOCK_USER_POS,
         "cube": 222,
+        "yahboom": DOCK_USER_POS,
+        "wonder_mv": DOCK_USER_POS,
     }
     fw_words_pos = fw_words_positions[board.config["type"]]
     u_data_words_pos = users_data_words_positions[board.config["type"]]

--- a/tests/pages/test_page.py
+++ b/tests/pages/test_page.py
@@ -112,7 +112,9 @@ def test_display_qr_code(mocker, m5stickv, mock_page_cls):
 
     assert ctx.input.wait_for_button.call_count == 1
     assert ctx.display.draw_qr_code.call_count == 1
-    assert ctx.display.draw_qr_code.call_args == mocker.call(0, TEST_QR_DATA_IMAGE)
+    assert ctx.display.draw_qr_code.call_args == mocker.call(
+        TEST_QR_DATA_IMAGE, 0, 0, 0
+    )
 
 
 def test_display_qr_code_light_theme(mocker, m5stickv, mock_page_cls):
@@ -131,7 +133,7 @@ def test_display_qr_code_light_theme(mocker, m5stickv, mock_page_cls):
     assert ctx.input.wait_for_button.call_count == 1
     assert ctx.display.draw_qr_code.call_count == 1
     assert ctx.display.draw_qr_code.call_args == mocker.call(
-        0, TEST_QR_DATA_IMAGE, light_color=WHITE
+        TEST_QR_DATA_IMAGE, 0, 0, 0, light_color=WHITE
     )
 
 
@@ -154,10 +156,10 @@ def test_display_qr_code_loop_through_brightness(mocker, m5stickv, mock_page_cls
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     assert ctx.display.draw_qr_code.call_count == len(BTN_SEQUENCE)
     assert ctx.display.draw_qr_code.call_args_list == [
-        mocker.call(0, TEST_QR_DATA_IMAGE),  # Default
-        mocker.call(0, TEST_QR_DATA_IMAGE, light_color=WHITE),  # Brighter
-        mocker.call(0, TEST_QR_DATA_IMAGE, light_color=DARKGREY),  # Darker
-        mocker.call(0, TEST_QR_DATA_IMAGE),  # Default
+        mocker.call(TEST_QR_DATA_IMAGE, 0, 0, 0),  # Default
+        mocker.call(TEST_QR_DATA_IMAGE, 0, 0, 0, light_color=WHITE),  # Brighter
+        mocker.call(TEST_QR_DATA_IMAGE, 0, 0, 0, light_color=DARKGREY),  # Darker
+        mocker.call(TEST_QR_DATA_IMAGE, 0, 0, 0),  # Default
     ]
 
 

--- a/tests/pages/test_qr_view.py
+++ b/tests/pages/test_qr_view.py
@@ -193,7 +193,7 @@ def test_load_qr_view(amigo, mocker):
     seed_qr_view.display_qr()
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     assert ctx.display.draw_qr_code.call_count == 8
-    assert ctx.display.draw_qr_code.call_args[0][1] == TEST_CODE_BINARY_QR
+    assert ctx.display.draw_qr_code.call_args[0][0] == TEST_CODE_BINARY_QR
 
 
 def test_load_seed_qr(amigo, mocker, tdata):
@@ -222,7 +222,6 @@ def test_load_seed_qr(amigo, mocker, tdata):
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     assert ctx.display.draw_qr_code.call_count == 8
     ctx.display.draw_qr_code.assert_called_with(
-        0,
         # Standard SeedQR
         SINGLE_SIG_12W_BINARY_QR,
     )
@@ -286,10 +285,10 @@ def test_loop_through_brightness(amigo, mocker):
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     assert ctx.display.draw_qr_code.call_count == 4
     assert ctx.display.draw_qr_code.call_args_list == [
-        mocker.call(0, TEST_CODE_BINARY_QR),  # Default
-        mocker.call(0, TEST_CODE_BINARY_QR, light_color=WHITE),  # Brighter
-        mocker.call(0, TEST_CODE_BINARY_QR, light_color=DARKGREY),  # Darker
-        mocker.call(0, TEST_CODE_BINARY_QR),  # Default
+        mocker.call(TEST_CODE_BINARY_QR),  # Default
+        mocker.call(TEST_CODE_BINARY_QR, light_color=WHITE),  # Brighter
+        mocker.call(TEST_CODE_BINARY_QR, light_color=DARKGREY),  # Darker
+        mocker.call(TEST_CODE_BINARY_QR),  # Default
     ]
 
 

--- a/tests/shared_mocks.py
+++ b/tests/shared_mocks.py
@@ -489,6 +489,56 @@ def board_cube():
     )
 
 
+def board_yahboom():
+    return mock.MagicMock(
+        config={
+            "type": "yahboom",
+            "lcd": {
+                "dcx": 31,
+                "ss": 30,
+                "rst": 23,
+                "clk": 28,
+                "height": 240,
+                "width": 320,
+                "invert": 1,
+                "dir": 96,
+                "lcd_type": 0,
+            },
+            "sdcard": {
+                "sclk": 32,
+                "mosi": 35,
+                "miso": 33,
+                "cs": 34,
+            },
+            "board_info": {
+                "BOOT_KEY": 16,
+                "CONNEXT_A": 8,
+                "CONNEXT_B": 6,
+                "I2C_SDA": 25,
+                "I2C_SCL": 24,
+                "SPI_SCLK": 32,
+                "SPI_MOSI": 35,
+                "SPI_MISO": 33,
+                "SPI_CS": 34,
+            },
+            "krux": {
+                "pins": {
+                    "BUTTON_B": 16,
+                    "BUTTON_C": 17,
+                    "TOUCH_IRQ": 22,
+                    "I2C_SDA": 25,
+                    "I2C_SCL": 24,
+                },
+                "display": {
+                    "touch": True,
+                    "font": [8, 16],
+                    "font_wide": [16, 16],
+                },
+            },
+        }
+    )
+
+
 def board_wonder_mv():
     return mock.MagicMock(
         config={
@@ -637,6 +687,27 @@ def mock_context(mocker):
                 draw_hcentered_text=mocker.MagicMock(return_value=1),
             ),
             light=None,
+        )
+    elif board.config["type"] == "yahboom":
+        return mocker.MagicMock(
+            input=mocker.MagicMock(
+                touch=mocker.MagicMock(),
+                enter_event=mocker.MagicMock(return_value=False),
+                page_event=mocker.MagicMock(return_value=False),
+                page_prev_event=mocker.MagicMock(return_value=False),
+                touch_event=mocker.MagicMock(return_value=False),
+            ),
+            display=mocker.MagicMock(
+                font_width=8,
+                font_height=16,
+                total_lines=20,  # 320 / 16
+                width=mocker.MagicMock(return_value=240),
+                height=mocker.MagicMock(return_value=320),
+                usable_width=mocker.MagicMock(return_value=(240 - 2 * 10)),
+                to_lines=mocker.MagicMock(return_value=[""]),
+                max_menu_lines=mocker.MagicMock(return_value=9),
+                draw_hcentered_text=mocker.MagicMock(return_value=1),
+            ),
         )
     elif board.config["type"] == "wonder_mv":
         return mocker.MagicMock(

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -794,3 +794,15 @@ def test_render_image_with_double_subtitle(mocker, multiple_devices):
         krux.display.lcd.display.assert_called_once_with(
             img, oft=(24, 0), roi=(72, 0, 186, 240)
         )
+
+
+def test_offset(mocker, multiple_devices):
+    from krux.display import Display, BOTTOM_LINE, MINIMAL_PADDING
+    from krux.kboard import kboard
+
+    d = Display()
+    if kboard.is_cube:
+        assert d.qr_offset() == BOTTOM_LINE
+    else:
+        assert d.qr_offset() == d.width() + MINIMAL_PADDING
+    assert d.qr_offset(10) == 10 + MINIMAL_PADDING

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -677,10 +677,10 @@ def test_draw_qr_code(mocker, m5stickv):
     d = Display()
     mocker.patch.object(d, "width", new=lambda: 135)
 
-    d.draw_qr_code(0, TEST_QR)
+    d.draw_qr_code(TEST_QR)
 
     krux.display.lcd.draw_qr_code_binary.assert_called_with(
-        0, TEST_QR, 135, QR_DARK_COLOR, QR_LIGHT_COLOR, QR_LIGHT_COLOR
+        0, 0, TEST_QR, 135, QR_DARK_COLOR, QR_LIGHT_COLOR, QR_LIGHT_COLOR
     )
 
 


### PR DESCRIPTION
### What is this PR for?
- About screen shows an QR code alongside some text, but cube was showing only the QR code.
- Now it is possible to print QR codes smaller than screen width - needs this MaixPy PR ->  https://github.com/selfcustody/MaixPy/pull/30


### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, cube and yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other, fixed feature only in develop
