### PR TITLE
`krux boot maixpy_project`: w/o flashing entire kboot.kfpkg to flash

### DIFF
--- a/krux
+++ b/krux
@@ -85,7 +85,12 @@ if [ "$1" == "build" ]; then
             echo "Wrong or unsupported device name, use maixpy_devicename"
         fi
     fi
-elif [ "$1" == "flash" ]; then
+elif [ "$1" == "flash" -o "$1" == "boot" ]; then
+    if [ "$1" == "flash" ]; then
+        CMD_SUFFIX="kboot.kfpkg"
+    else
+        CMD_SUFFIX="-s firmware.bin"
+    fi
     device="$2"
     if [ -z "$device" ]; then
         echo "Missing device"
@@ -121,7 +126,7 @@ elif [ "$1" == "flash" ]; then
             BOARD="goE"
         fi
 
-        if ! docker run --device=/dev/$usb_device_name:/dev/ttyUSB0 --rm -w "$BUILD_DIR" -it krux-builder python3 ktool.py -B "$BOARD" -p /dev/ttyUSB0 -b 1500000 kboot.kfpkg; then
+        if ! docker run --device=/dev/$usb_device_name:/dev/ttyUSB0 --rm -w "$BUILD_DIR" -it krux-builder python3 ktool.py -B "$BOARD" -p /dev/ttyUSB0 -b 1500000 $CMD_SUFFIX; then
             # M5stickV has only one serial port
             # Bit has two serial ports and uses first for flash
             # Amigo has two ports and uses second port to flash
@@ -131,7 +136,7 @@ elif [ "$1" == "flash" ]; then
                 if [ -z "$usb_device_name" ]; then
                     panic "Failed to find device via USB. Is it connected and powered on?"
                 fi
-                docker run --device=/dev/$usb_device_name:/dev/ttyUSB0 --rm -w "$BUILD_DIR" -it krux-builder python3 ktool.py -B "$BOARD" -p /dev/ttyUSB0 -b 1500000 kboot.kfpkg
+                docker run --device=/dev/$usb_device_name:/dev/ttyUSB0 --rm -w "$BUILD_DIR" -it krux-builder python3 ktool.py -B "$BOARD" -p /dev/ttyUSB0 -b 1500000 $CMD_SUFFIX
             fi
         fi
     fi


### PR DESCRIPTION
  ...when you only want to try a sample firmware temporarily.
* "flash" still flashes kboot.kfpkg to device flash
* "boot" loads firmware.bin into device sram, then resets board to boot from sram

### What is this PR for?
Uses ktool's `-s` flag to write firmware.bin into sram without flashing bootloaders/config/firmware to device flash,
Spares unnecessary writes to flash, hardly any faster, but can reset board and boot from a known firmware when just playing with small changes.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
