### PR TITLE
Cover `has_battery` in `src/krux/power.py` when device has no battery

### DIFF
--- a/src/krux/power.py
+++ b/src/krux/power.py
@@ -50,7 +50,10 @@ class PowerManager:
         try:
             if int(self.pmu.get_battery_voltage()) <= 0:
                 return False
-        except:
+        # If the device does not have a battery,
+        # the PMUController will not have the get_battery_voltage method
+        # and it will raise an AttributeError
+        except AttributeError:
             return False
         return True
 

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_init(mocker, multiple_devices):
     from krux.power import PowerManager
 
@@ -33,6 +36,30 @@ def test_charge_remaining(mocker, multiple_devices):
         assert manager.battery_charge_remaining() == 0.9
     elif board.config["type"] in ("m5stickv", "cube"):
         assert round(manager.battery_charge_remaining(), 2) == 0.75
+
+
+def test_charge_has_no_battery(mocker, multiple_devices):
+    from krux.power import PowerManager
+    import board
+
+    manager = PowerManager()
+
+    # M5StickV, Amigo and Cube have battery
+    # and calls get_battery_voltage
+    if board.config["type"] in ("amigo", "m5stickv", "cube"):
+        manager.pmu.get_battery_voltage = mocker.MagicMock(return_value=0)
+        assert not manager.has_battery()
+        manager.pmu.get_battery_voltage.assert_called_once()
+
+    # Dock, Yahboom and WonderMV do not have battery
+    # it just raises an exception and returns False
+    else:
+        with pytest.raises(AttributeError) as exc_info:
+            assert not manager.has_battery()
+            assert (
+                str(exc_info.exception)
+                == "get_battery_voltage() not implemented for this board"
+            )
 
 
 def test_shutdown(mocker, m5stickv):


### PR DESCRIPTION
### What is this PR for?

Cover `has_battery` in `src/krux/power.py` when device has no battery

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: coverage
