### PR TITLE
Expand keypad touch area

### DIFF
--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -63,8 +63,9 @@ class KeypadLayout:
             for y in range(self.height + 1)
         ]
         self.x_keypad_map = [
-            x * key_h_spacing + MINIMAL_PADDING for x in range(self.width + 1)
+            x * key_h_spacing + MINIMAL_PADDING for x in range(self.width)
         ]
+        self.x_keypad_map.append(ctx.display.width())
         if ctx.input.touch is not None:
             ctx.input.touch.set_regions(self.x_keypad_map, self.y_keypad_map)
 


### PR DESCRIPTION
### What is this PR for?
Fix the issue where touches on the rightmost column of the keypad did not register on the WonderMV device.



### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
