### PR TITLE
try/except decodings in decrypt_kef

### DIFF
--- a/src/krux/pages/encryption_ui.py
+++ b/src/krux/pages/encryption_ui.py
@@ -56,13 +56,25 @@ def decrypt_kef(ctx, data):
         for encoding in encodings:
             as_bytes = None
             if encoding in ("hex", "HEX"):
-                as_bytes = unhexlify(data)
+                try:
+                    as_bytes = unhexlify(data)
+                except:
+                    continue
             elif encoding == 32:
-                as_bytes = base_decode(data, 32)
+                try:
+                    as_bytes = base_decode(data, 32)
+                except:
+                    continue
             elif encoding == 64:
-                as_bytes = base_decode(data, 64)
+                try:
+                    as_bytes = base_decode(data, 64)
+                except:
+                    continue
             elif encoding == 43:
-                as_bytes = base_decode(data, 43)
+                try:
+                    as_bytes = base_decode(data, 43)
+                except:
+                    continue
 
             if as_bytes:
                 kef_envelope = KEFEnvelope(ctx)


### PR DESCRIPTION
### What is this PR for?

baseconv.detect_encodings() only "hints" of a list of encodings that should be tried.
Therefore encryption_ui() must actually try/except these not-yet-validated encoding hints.

Previous to this pr, a failed decoding was raising an exception and other encoding hints were not tried.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
