### PR TITLE
Double mnemonic * indicator when load by numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Exported QR codes can now be saved as SVG images.
 - Keypad touch area has been expanded to the screen edges.
 - "Tools > Print Test QR" now asks for user confirmation before printing.
 - "Tools > Check SD Card" now allows deleting files.
+- "Load mnemonic > Via Manual Input > Word Numbers" now shows the double mnemonic indicator (*) if it is a double mnemonic.
 - Added fingerprint to mnemonic preview and editor.
 - Fingerprint preview now shown when changing wallet passphrase.
 - Saving encrypted mnemonic now prompts whether to use the fingerprint as ID.

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -400,8 +400,9 @@ class Login(Page):
         }
         numbers_str = Utils.get_mnemonic_numbers(mnemonic, charset_type[charset])
         self.display_mnemonic(
-            numbers_str,
+            mnemonic,
             suffix_dict[charset],
+            numbers_str,
             fingerprint=Key.extract_fingerprint(mnemonic),
         )
         if not self.prompt(t("Proceed?"), BOTTOM_PROMPT_LINE):


### PR DESCRIPTION
### What is this PR for?
Double mnemonic indicator (*) was not appearing when loading a wallet by numbers.


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
