### PR TITLE
hide mnemonic ignores confirmation for load via numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Exported QR codes can now be saved as SVG images.
 - Added QR Code to About screen.
 - Wallet Descriptor now validates and warns if change addresses cannot be determined.
 - Hide the "Change Addresses" menu option when cannot be determined by the wallet descriptor.
+- The hide mnemonic setting now ignores user confirmation when loading a mnemonic via word numbers.
 - Minor text improvements for clarity and easier translation.
 
 

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -274,12 +274,13 @@ class Login(Page):
     def _load_key_from_words(self, words, charset=LETTERS, new=False):
         mnemonic = " ".join(words)
 
-        if charset != LETTERS:
-            if self._confirm_key_from_digits(mnemonic, charset) is not None:
-                return MENU_CONTINUE
-
-        # If the mnemonic is not hidden, show the mnemonic editor
+        # Don't show word list confirmation or the mnemonic editor if hide mnemonic is enabled
         if not Settings().security.hide_mnemonic:
+
+            if charset != LETTERS:
+                if self._confirm_key_from_digits(mnemonic, charset) is not None:
+                    return MENU_CONTINUE
+
             from .mnemonic_editor import MnemonicEditor
 
             mnemonic = MnemonicEditor(self.ctx, mnemonic, new).edit()


### PR DESCRIPTION
### What is this PR for?
Ignores confirmation when loading via numbers with hide mnemonic enabled.


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
