### PR TITLE
Add test for ESC key handling in `tests/pages/test_tc_code_verification.py`

### DIFF
--- a/tests/pages/test_tc_code_verification.py
+++ b/tests/pages/test_tc_code_verification.py
@@ -73,3 +73,26 @@ def test_tc_code_verification(amigo, mocker):
             keypad_label,
             [NUM_SPECIAL_1, LETTERS, UPPERCASE_LETTERS, NUM_SPECIAL_2],
         )
+
+
+def test_tc_code_verification_esc_key(amigo, mocker):
+    from krux.pages import ESC_KEY
+    from krux.pages.tc_code_verification import TCCodeVerification
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV
+
+    # Simulate user pressing ESC key
+    BTN_SEQUENCE = [
+        BUTTON_PAGE_PREV,  # Navigate to ESC key
+        BUTTON_PAGE_PREV,  # Navigate to ESC key
+        BUTTON_ENTER,      # Press ESC key
+        BUTTON_ENTER,      # Confirm "Yes" in prompt
+    ]
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    tc_verifier = TCCodeVerification(ctx)
+    
+    # Test full user interaction flow
+    result = tc_verifier.capture()
+    
+    assert result == False
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)


### PR DESCRIPTION
### What is this PR for?  

Improve test coverage for `tc_code_verification.py` to 100% by adding missing ESC key handling test case.

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other : Add test for ESC key handling in `/tests/pages/test_tc_code_verification.py`
