### PR TITLE
bug: fix M5stickV display size verification on `export_1248`

### DIFF
--- a/src/krux/pages/stack_1248.py
+++ b/src/krux/pages/stack_1248.py
@@ -215,7 +215,7 @@ class Stackbit(Page):
 
         self.x_offset = DEFAULT_PADDING
         # case for m5stickv
-        if self.ctx.display.width() < NARROW_SCREEN_WITH:
+        if self.ctx.display.width() <= NARROW_SCREEN_WITH:
             self.x_offset = 5
         self.x_pad = 2 * FONT_WIDTH
         self.y_offset = 2 * FONT_HEIGHT


### PR DESCRIPTION
### What is this PR for?

* `self.ctx.display.width()` will return a value equals to `NARROW_SCREEN_WITH` and never hits the line `self.x_offset = 5`;
* replacing `<` to `<=` allow to hit the line and adjust the screen on M5stickV.

Just for comparison, some photos from simulator:

**Without the change**

<img src="https://github.com/user-attachments/assets/e050e5c6-4fd2-4924-9e28-74ea7b09c8c6" title="without the change" alt="without the change"/>

**With the change**

<img src="https://github.com/user-attachments/assets/d90699d8-d7b6-4fb6-b4be-eabb8e26d2e8" title="with the change" alt="with the change"/>

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes (i don't have a M5stickV)


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
