### PR TITLE
chore: move shebang to top of `krux` script

### DIFF
--- a/krux
+++ b/krux
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 # The MIT License (MIT)
 
-# Copyright (c) 2021-2023 Krux contributors
+# Copyright (c) 2021-2025 Krux contributors
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-#!/bin/bash
 set -e
 
 FIRMWARE_DIR="/src/firmware"


### PR DESCRIPTION
### What is this PR for?

Fix #636

* Moves the /bin/bash shebang to the top so it not break `zsh` environments;
* update year of Copyright.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other: 
