### PR TITLE
Firmware update now checks for the correct device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ SHA-256 and PBKDF2-HMAC now leverage hardware-accelerated hashing, doubling the 
 
 ### SD Card Airgapped Firmware Upgrade Optimizations
 - Verifies firmware signature authenticity before prompting the user to update.
+- Ensures that only compatible firmware can be installed on the device.
 - Displays the firmware version being installed for user confirmation.
 - Hardware-accelerated SHA-256 hashing and other optimizations speeds up checks.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ simulator-wonder-mv = "python simulator/simulator.py --device maixpy_wonder_mv"
 simulator.ref = "simulator-amigo"
 simulator-m5.ref = "simulator-m5stickv"
 simulator-mv.ref = "simulator-wonder-mv"
+simulator-wonder.ref = "simulator-wonder-mv"
+simulator-wondermv.ref = "simulator-wonder-mv"
 
 # git tasks
 git-update = "git submodule update --init --recursive"


### PR DESCRIPTION
### What is this PR for?
Avoid SD firmware update if file is from another device.


### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
