### PR TITLE
Fix Docker firmware build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ pubkey.pem
 simulator/krux-screenshots
 simulator/screenshots
 simulator/sd
+simulator/flash
 
 # allow files: firmware.bin, .sig, .sha256.txt
 !tests/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@
 # build-base
 # install kendryte (k210), cmake and python dependencies
 ############
-FROM gcc:9.4.0-buster AS build-base
+FROM gcc:9.5.0-bullseye AS build-base
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q \
@@ -96,7 +96,7 @@ RUN find vendor/urtypes -type d -name '__pycache__' -exec rm -rv {} + -depth
 RUN find vendor/foundation-ur-py -type d -name '__pycache__' -exec rm -rv {} + -depth
 
 # install vendor/embit
-RUN cd vendor/embit && pip3 install -e .
+RUN pip3 install vendor/embit
 # clean vendor/embit
 RUN rm -rf vendor/embit/src/embit/util/prebuilt && \
     rm -rf vendor/embit/src/embit/liquid && \


### PR DESCRIPTION
### What is this PR for?
**Debian 10**, also known as **Buster**, reached its End of Life (EOL) on **June 30, 2024**. This is why we get 404 during Docker build process as shown below using `GCC:9.4.0`. The fix uses **Debian 11 (bullseye)** that has Long-Term Support (LTS) phase, which will provide security updates **until August 31, 2026**.

```
=> ERROR [build-base 2/7] RUN apt-get update -y &&     apt-get install --no-install-recommends -y -q         wget         tar         zip ..........
0.689 Ign:1 http://security.debian.org/debian-security buster/updates InRelease
0.698 Ign:2 http://deb.debian.org/debian buster InRelease
0.701 Err:3 http://security.debian.org/debian-security buster/updates Release
0.701   404  Not Found [IP: 151.101.250.132 80]
0.710 Ign:4 http://deb.debian.org/debian buster-updates InRelease
0.728 Err:5 http://deb.debian.org/debian buster Release
0.728   404  Not Found [IP: 151.101.250.132 80]
0.742 Err:6 http://deb.debian.org/debian buster-updates Release
0.742   404  Not Found [IP: 151.101.250.132 80]
0.745 Reading package lists...
0.751 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
0.751 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
0.751 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```


### Changes made to:
- [x] Code (not firmware code)
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, yahboom (device tests, xpub, addresses, sign PSBT / message)


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
