### PR TITLE
Change "assert..." to "if not ...: raise ValueError"

### DIFF
--- a/src/krux/baseconv.py
+++ b/src/krux/baseconv.py
@@ -130,10 +130,7 @@ def detect_encodings(str_data):
 
 # pure-python encoder/decoder for base43 and base58 below
 B43CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$*+-./:"
-assert len(B43CHARS) == 43
-
 B58CHARS = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-assert len(B58CHARS) == 58
 
 
 def pure_python_base_decode(v, base):

--- a/src/krux/kef.py
+++ b/src/krux/kef.py
@@ -409,25 +409,32 @@ def wrap(id_, version, iterations, payload):
     try:
         # when wrapping, be tolerant about id_ as bytes or str
         id_ = id_ if isinstance(id_, bytes) else id_.encode()
-        assert 0 <= len(id_) <= 252
+        if not 0 <= len(id_) <= 252:
+            raise ValueError
         len_id = len(id_).to_bytes(1, "big")
     except:
         raise ValueError("Invalid ID")
 
     try:
-        assert 0 <= version <= 255
-        assert VERSIONS[version] is not None
-        assert VERSIONS[version]["mode"] is not None
+        if not (
+            0 <= version <= 255
+            and VERSIONS[version] is not None
+            and VERSIONS[version]["mode"] is not None
+        ):
+            raise ValueError
     except:
         raise ValueError("Invalid version")
 
     try:
-        assert isinstance(iterations, int)
+        if not isinstance(iterations, int):
+            raise ValueError
         if iterations % 10000 == 0:
             iterations = iterations // 10000
-            assert 1 <= iterations <= 10000
+            if not 1 <= iterations <= 10000:
+                raise ValueError
         else:
-            assert 10000 < iterations < 2**24
+            if not 10000 < iterations < 2**24:
+                raise ValueError
         iterations = iterations.to_bytes(3, "big")
     except:
         raise ValueError("Invalid iterations")
@@ -456,8 +463,8 @@ def unwrap(kef_bytes):
     try:
         # out-of-order reading to validate version early
         version = kef_bytes[1 + len_id]
-        assert VERSIONS[version] is not None
-        assert VERSIONS[version]["mode"] is not None
+        if VERSIONS[version] is None or VERSIONS[version]["mode"] is None:
+            raise ValueError
     except:
         raise ValueError("Invalid format")
 

--- a/src/krux/pages/datum_tool.py
+++ b/src/krux/pages/datum_tool.py
@@ -244,8 +244,8 @@ def detect_encodings(str_data, verify=True):
             try:
                 # binascii.a2b_base64 is NOT strict
                 as_bytes = base_decode(str_data, 64)
-                assert base_encode(as_bytes, 64) == str_data
-                encodings.append(64)
+                if base_encode(as_bytes, 64) == str_data:
+                    encodings.append(64)
             except:
                 pass
         else:

--- a/src/krux/pages/device_tests.py
+++ b/src/krux/pages/device_tests.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 from . import Page, Menu, MENU_CONTINUE
-from ..display import DEFAULT_PADDING, FONT_HEIGHT, FONT_WIDTH, BOTTOM_PROMPT_LINE
+from ..display import DEFAULT_PADDING, FONT_HEIGHT, FONT_WIDTH
 from ..krux_settings import t
 from ..wdt import wdt
 
@@ -53,21 +53,22 @@ class DeviceTests(Page):
         utils.print_standard_qr(title, title=title, check_printer=False)
         return MENU_CONTINUE
 
+    # pylint: disable=W0613
     def test_suite(self, interactive=False):
         """run each on-device tests in all_tests, report summary and details"""
         all_tests = [
             self.hw_acc_hashing,
             self.deflate_compression,
             self.touch_gestures,
-            # all below are prototyping/pseudo-tests
-            self.test_success,
-            self.test_non_empty,
-            self.test_long_named_test_function,
-            (self.test_interactive, interactive),  # interactive test
-            self.test_exception,  # failure
-            self.test_false,  # failure
-            self.test_empty,  # failure
-            self.test_none,  # failure
+            # # all below are prototyping/pseudo-tests
+            # self.test_success,
+            # self.test_non_empty,
+            # self.test_long_named_test_function,
+            # (self.test_interactive, interactive),  # interactive test
+            # self.test_exception,  # failure
+            # self.test_false,  # failure
+            # self.test_empty,  # failure
+            # self.test_none,  # failure
         ]
 
         self.ctx.display.clear()
@@ -86,12 +87,13 @@ class DeviceTests(Page):
                     if not callable(test):
                         test_fn = test[0]
                         args = test[1 : len(test)]
-                        assert test_fn(*args)
+                        if not test_fn(*args):
+                            raise ValueError
                         self.results.append((test_fn, True))
                     else:
-                        assert test()
+                        if not test():
+                            raise ValueError
                         self.results.append((test, True))
-
                 except Exception as err:
                     print(
                         "DeviceTests.run_test_suite: {} failed: {}".format(
@@ -201,7 +203,10 @@ class DeviceTests(Page):
     # * return False/empty/None/Exception on failure
 
     def hw_acc_hashing(self, interactive=False):
-        """churns nonce through sha256() and pbkdf_hmac(sha256,) calls, asserts expected results"""
+        """
+        churns nonce through sha256() and pbkdf_hmac(sha256,) calls,
+        raises ValueError if calculated results don't match expected results
+        """
         from uhashlib_hw import sha256 as f_hash
         from uhashlib_hw import pbkdf2_hmac_sha256 as f_hmac
 
@@ -257,7 +262,8 @@ class DeviceTests(Page):
         err = ""
         for i, (expected, calculated) in enumerate(zip(expecteds, calculateds)):
             try:
-                assert expected == calculated
+                if expected != calculated:
+                    raise ValueError("test failed")
                 results.append("test case {}: ok".format(i))
             except:
                 err += "\nTest case: {}\n   expected: {}\n calculated: {}".format(
@@ -344,32 +350,33 @@ class DeviceTests(Page):
 
         return True
 
-    # next 8 tests below are prototyping/pseudo-tests -- these will be removed
-    # pylint: disable=C0116
-    def test_success(self, interactive=False):
-        return True
+    # # next 8 tests below are prototyping/pseudo-tests
+    # # pylint: disable=C0116
+    # def test_success(self, interactive=False):
+    #     return True
 
-    def test_non_empty(self, interactive=False):
-        return "it worked"
+    # def test_non_empty(self, interactive=False):
+    #     return "it worked"
 
-    def test_exception(self, interactive=False):
-        raise ValueError("ValueError raised")
+    # def test_exception(self, interactive=False):
+    #     raise ValueError("ValueError raised")
 
-    def test_false(self, interactive=False):
-        return False
+    # def test_false(self, interactive=False):
+    #     return False
 
-    def test_empty(self, interactive=False):
-        return []
+    # def test_empty(self, interactive=False):
+    #     return []
 
-    def test_none(self, interactive=False):
-        pass
+    # def test_none(self, interactive=False):
+    #     pass
 
-    def test_long_named_test_function(self, interactive=False):
-        return True
+    # def test_long_named_test_function(self, interactive=False):
+    #     return True
 
-    def test_interactive(self, interactive=False):
-        if not interactive:
-            return "Cannot test non-interactively"
-        return self.prompt(
-            "Printer go Brrr...\nSeparate money and state?", BOTTOM_PROMPT_LINE
-        )
+    # def test_interactive(self, interactive=False):
+    #     from ..display import BOTTOM_PROMPT_LINE
+    #     if not interactive:
+    #         return "Cannot test non-interactively"
+    #     return self.prompt(
+    #         "Printer go Brrr...\nSeparate money and state?", BOTTOM_PROMPT_LINE
+    #     )

--- a/tests/pages/test_device_tests.py
+++ b/tests/pages/test_device_tests.py
@@ -189,7 +189,7 @@ def test_fail_hw_acc_hashing(m5stickv, mocker, mock_hw_acc_hashing):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -221,7 +221,7 @@ def test_fail_sha256(m5stickv, mocker, mock_hashlib_sha256):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -255,7 +255,7 @@ def test_fail_hexilify(m5stickv, mocker, mock_hexlify_endianess):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -289,7 +289,7 @@ def test_fail_b2a_base64(m5stickv, mocker, mock_b2a_base64_endianess):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -309,7 +309,7 @@ def test_fail_deflate_compression(m5stickv, mocker, mock_deflate):
     page = DeviceTests(ctx)
     page.test_suite()
 
-    # assert that the deflate_compress and deflate_decmpress were called
+    # assert that the deflate_compress and deflate_decompress were called
     deflate_compress, deflate_decompress = mock_deflate
     deflate_compress.assert_has_calls(
         [
@@ -332,7 +332,7 @@ def test_fail_deflate_compression(m5stickv, mocker, mock_deflate):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -360,7 +360,7 @@ def test_fail_maixpy_code(m5stickv, mocker, mock_maixpy_code):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -388,7 +388,7 @@ def test_fail_zlib_code(m5stickv, mocker, mock_zlib_code):
     page.ctx.display.draw_hcentered_text.assert_has_calls(
         [
             mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
+                "Test Suite Results\nsuccess rate: 66%\nfailed: 1/3", info_box=True
             )
         ]
     )
@@ -407,16 +407,8 @@ def test_run_test_suite_only(m5stickv, mocker):
     page = DeviceTests(ctx)
     page.test_suite()
 
-    # while prototyping: run_test_suite() purposely fails 4 of 10 tests
-    # page.ctx.display.draw_hcentered_text.assert_has_calls([mocker.call(
-    #    "Test Suite Results\nsuccess rate: 100%", info_box=True
-    # )])
     page.ctx.display.draw_hcentered_text.assert_has_calls(
-        [
-            mocker.call(
-                "Test Suite Results\nsuccess rate: 63%\nfailed: 4/11", info_box=True
-            )
-        ]
+        [mocker.call("Test Suite Results\nsuccess rate: 100%", info_box=True)]
     )
 
 
@@ -436,16 +428,8 @@ def test_run_test_suite_plus_individual_test(m5stickv, mocker):
     page = DeviceTests(ctx)
     page.test_suite()
 
-    # while prototyping: run_test_suite() purposely fails 4 of 11 tests
-    # page.ctx.display.draw_hcentered_text.assert_has_calls([mocker.call(
-    #    "Test Suite Results\nsuccess rate: 100%", info_box=True
-    # )])
     page.ctx.display.draw_hcentered_text.assert_has_calls(
-        [
-            mocker.call(
-                "Test Suite Results\nsuccess rate: 63%\nfailed: 4/11", info_box=True
-            )
-        ]
+        [mocker.call("Test Suite Results\nsuccess rate: 100%", info_box=True)]
     )
 
 
@@ -465,19 +449,8 @@ def test_run_intreactively(m5stickv, mocker):
     page = DeviceTests(ctx)
     page.test_suite(interactive=True)
 
-    # while prototyping: run_test_suite() purposely fails 4 of 11 tests
-    # page.ctx.display.draw_hcentered_text.assert_has_calls([mocker.call(
-    #    "Test Suite Results\nsuccess rate: 100%", info_box=True
-    # )])
-    #
-
-    # some tests will fail by non interactivity
     page.ctx.display.draw_hcentered_text.assert_has_calls(
-        [
-            mocker.call(
-                "Test Suite Results\nsuccess rate: 54%\nfailed: 5/11", info_box=True
-            )
-        ]
+        [mocker.call("Test Suite Results\nsuccess rate: 100%", info_box=True)]
     )
 
 


### PR DESCRIPTION
### What is this PR for?

Alters `assert` to `if ...: raise...` introduced recently in:
* kef library and datum_tool,
* baseconv: asserts that check constants removed entirely, not replaced,
* device_tests: and also comments-out no-longer-necessary pseudo-tests
... so that these logical checks are not avoided:
* via python's `-O` optimize flag,
* when integrated into android for krux mobile app




### Changes made to:
- [X] Code
- [X] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes (amigo and simulator


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other (avoid special branch for android which strips `assert` statements)
