### PR TITLE
Fix camera not rotating with flipped orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Exported QR codes can now be saved as SVG images.
 - Saving encrypted mnemonic now prompts whether to use the fingerprint as ID.
 - Optimized device's board value checks.
 - Added QR Code to About screen.
+- Fixed camera not rotating on Yahboom or WonderMV with flipped orientation.
+- Restart prompt for theme settings now appears only when changes are made.
 - Wallet Descriptor now validates and warns if change addresses cannot be determined.
 - Wallet customization prompt now warns about Descriptor unloading, but does nothing if no changes are made.
 - Fixed issues with long wallet derivation path.

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -452,22 +452,31 @@ class SettingsPage(Page):
     def _category_change_exit_check(
         self, settings_namespace, setting, starting_category
     ):
-        if setting.attr in ("locale", "hide_mnemonic"):
-            # If locale or hide changed, needs to recreate Login
-            if setting.__get__(settings_namespace) != starting_category:
+        # Check if category changed
+        if setting.__get__(settings_namespace) != starting_category:
+            if setting.attr in ("locale", "hide_mnemonic"):
+                # If locale or hide changed, needs to recreate Login
                 return MENU_EXIT
-        elif setting.attr == "theme":
-            self.ctx.display.clear()
-            if self.prompt(
-                t("Change theme and reboot?"), self.ctx.display.height() // 2
-            ):
-                self._settings_exit_check()
+            if setting.attr == "theme":
                 self.ctx.display.clear()
-                self.ctx.power_manager.reboot()
-                return MENU_EXIT  # In case reboot fails
-            # Restore previous theme
-            setting.__set__(settings_namespace, starting_category)
-            theme.update()
+                if self.prompt(
+                    t("Change theme and reboot?"), self.ctx.display.height() // 2
+                ):
+                    self._settings_exit_check()
+                    self.ctx.display.clear()
+                    self.ctx.power_manager.reboot()
+                    return MENU_EXIT  # In case reboot fails
+                # Restore previous theme
+                setting.__set__(settings_namespace, starting_category)
+                theme.update()
+            if setting.attr == "flipped_orientation":
+                # need to recreate camera singleton
+                from ..camera import Camera
+
+                self.ctx.display.clear()
+                self.ctx.display.draw_centered_text(t("Processing.."))
+
+                self.ctx.camera = Camera()
 
         return MENU_CONTINUE
 


### PR DESCRIPTION
### What is this PR for?
- Fixed camera not rotating on Yahboom or WonderMV with flipped orientation.
- Restart prompt for theme settings now appears only when changes are made.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, Yahboom


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
