### PR TITLE
bugfix: to differentiate between "failed to decrypt",

### DIFF
--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -293,7 +293,8 @@ class Addresses(Page):
 
         try:
             data = decrypt_kef(self.ctx, data).decode()
-        except:
+        except ValueError:
+            # ValueError=not KEF or declined to decrypt; KeyError=failed to decrypt
             pass
 
         addr = None

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -463,7 +463,8 @@ class Home(Page):
             from ..encryption_ui import decrypt_kef
 
             data = decrypt_kef(self.ctx, data)
-        except:
+        except ValueError:
+            # ValueError=not KEF or declined to decrypt; KeyError=failed to decrypt
             pass
 
         # PSBT read OK! Will try to sign

--- a/src/krux/pages/home_pages/wallet_descriptor.py
+++ b/src/krux/pages/home_pages/wallet_descriptor.py
@@ -163,7 +163,8 @@ class WalletDescriptor(Page):
 
         try:
             wallet_data = decrypt_kef(self.ctx, wallet_data).decode()
-        except:
+        except ValueError:
+            # ValueError=not KEF or declined to decrypt; KeyError=failed to decrypt
             pass
 
         from ...wallet import Wallet, AssumptionWarning

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -484,7 +484,8 @@ class Login(Page):
 
         try:
             data = decrypt_kef(self.ctx, data)
-        except:
+        except ValueError:
+            # ValueError=not KEF or declined to decrypt; KeyError=failed to decrypt
             pass
 
         words = []

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -124,7 +124,8 @@ class PassphraseEditor(Page):
 
         try:
             data = decrypt_kef(self.ctx, data).decode()
-        except:
+        except ValueError:
+            # ValueError=not KEF or declined to decrypt; KeyError=failed to decrypt
             pass
 
         if len(data) > PASSPHRASE_MAX_LEN:

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -601,7 +601,7 @@ def test_encryption_key_strength(m5stickv, mocker):
 def test_decrypt_kef(m5stickv, mocker):
     """Verify that decrypt_kef attempts to unseal kef-envelope(s)"""
     from krux.pages.encryption_ui import decrypt_kef
-    from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
     from krux import kef
 
     plaintext = b"this is plain text"
@@ -637,6 +637,39 @@ def test_decrypt_kef(m5stickv, mocker):
     result = decrypt_kef(ctx, envelope)
     assert result == plaintext
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # wrong decryption key will result in KeyError raised from decrypt_kef's call
+    # to KEFEnvelope.unseal_ui() and does NOT catch it, allows KeyError to bubble up
+    # callers decrypt_kef() can not catch KeyError and instead allow it to bubble up
+    BTN_SEQUENCE = [
+        BUTTON_ENTER,  # external envelope "Decrypt?"
+        BUTTON_ENTER,  # enter key
+        BUTTON_ENTER,  # "a" as key
+        BUTTON_PAGE_PREV,  # move to "Go"
+        BUTTON_ENTER,  # Go
+        BUTTON_ENTER,  # Confirm "a" as key
+    ]
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    with pytest.raises(KeyError, match="Failed to decrypt"):
+        decrypt_kef(ctx, envelope)
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # declining to decrypt results in ValueError("Not decrypted")
+    # which callers of decrypt_kef() will likely catch to deal with original data
+    BTN_SEQUENCE = [
+        BUTTON_PAGE_PREV,  # decline to "Decrypt?"
+    ]
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    with pytest.raises(ValueError, match="Not decrypted"):
+        decrypt_kef(ctx, envelope)
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # as well, nothing to decrypt also results in ValueError("Not decrypted")
+    # which callers of decrypt_kef() will likely catch to deal with original data
+    ctx = create_ctx(mocker, [])
+    with pytest.raises(ValueError, match="Not decrypted"):
+        decrypt_kef(ctx, "I am not a valid KEF envelope")
+    assert ctx.input.wait_for_button.call_count == 0
 
 
 def test_decrypt_kef_offers_decrypt_ui_appriately(m5stickv, mocker):
@@ -1103,7 +1136,7 @@ def test_kefenvelope_input_key_ui(m5stickv, mocker):
         QRCodeCapture,
         "qr_capture_loop",
         new=lambda self: (
-            b"\x06binkey\x05\x01\x88WB\xb9\xab\xb6\xe9\x83\x97y\x1ab\xb0F\xe2|\xd3E\x11\xef\x9a",
+            b"\x06binkey\x05\x01\x88WB\xb9\xab\xb6\xe9\x83\x97y\x1ab\xb0F\xe2|\xd3E\x84\x2b\x2c",
             None,
         ),
     )


### PR DESCRIPTION
### What is this PR for?
Correctly showing "Failed to decrypt" on wrong decryption key, instead of allowing execution to continue with wrong assumption that original data is worth parsing.

Callers of `encryption_ui.decrypt_kef` were catching all errors, instead of ValueError, and were not deciphering for the important case of `KeyError("Failed to decrypt)` which shouldn't be caught and should disrupt flow.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
