### PR TITLE
Displays passphrase and key length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Exported QR codes can now be saved as SVG images.
 - "Load mnemonic > Via Manual Input > Word Numbers" now shows the double mnemonic indicator (*) if it is a double mnemonic.
 - Added fingerprint to mnemonic preview and editor.
 - Fingerprint preview now shown when changing wallet passphrase.
+- Passphrase and key now display their length after entry to reduce user mistakes.
 - Saving encrypted mnemonic now prompts whether to use the fingerprint as ID.
 - Optimized device's board value checks.
 - Added QR Code to About screen.

--- a/src/krux/pages/encryption_ui.py
+++ b/src/krux/pages/encryption_ui.py
@@ -471,7 +471,9 @@ class EncryptionKey(Page):
             offset_y = DEFAULT_PADDING
             displayable = key if isinstance(key, str) else "0x" + hexlify(key).decode()
             key_lines = self.ctx.display.draw_hcentered_text(
-                "{}: {}".format(t("Key"), displayable), offset_y, highlight_prefix=":"
+                "{} ({}): {}".format(t("Key"), len(key), displayable),
+                offset_y,
+                highlight_prefix=":",
             )
 
             if creating:

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -331,7 +331,9 @@ class Login(Page):
                 network_name, policy_type, script_type, derivation_path, True
             )
             wallet_info += "\n" + (
-                t("No Passphrase") if not passphrase else t("Passphrase") + ": *..*"
+                t("No Passphrase")
+                if not passphrase
+                else t("Passphrase") + " (%d): *..*" % len(passphrase)
             )
 
             self.ctx.display.clear()

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -90,7 +90,7 @@ class PassphraseEditor(Page):
                 color=theme.highlight_color,
             )
             self.ctx.display.draw_hcentered_text(
-                t("Passphrase") + ":",
+                t("Passphrase") + " (%d):" % len(passphrase),
                 DEFAULT_PADDING + FONT_HEIGHT * 2,
                 theme.highlight_color,
             )


### PR DESCRIPTION
### What is this PR for?
Displays passphrase an key length upon entry as a clear indicator to reduce user mistakes.


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, yahboom


### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
