### PR TITLE
fix: add check for empty passphrases 

### DIFF
--- a/i18n/translations/de-DE.json
+++ b/i18n/translations/de-DE.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Doppelte Gedächtnisstütze",
     "Driver": "Driver",
     "Empty": "Leer",
+    "Empty passphrase": "Leere Passphrase",
     "Enable?": "Aktivieren?",
     "Encrypt": "Verschlüsseln",
     "Encrypted": "Verschlüsselt",

--- a/i18n/translations/es-MX.json
+++ b/i18n/translations/es-MX.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Doble mnemónico",
     "Driver": "Operador",
     "Empty": "Vacío",
+    "Empty passphrase": "Contraseña vacía",
     "Enable?": "¿Permitir?",
     "Encrypt": "Cifrar",
     "Encrypted": "Cifrado",

--- a/i18n/translations/fr-FR.json
+++ b/i18n/translations/fr-FR.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Double mnémonique",
     "Driver": "Pilote",
     "Empty": "Vide",
+    "Empty passphrase": "Passe vide",
     "Enable?": "Activer ?",
     "Encrypt": "Chiffrer",
     "Encrypted": "Chiffré",

--- a/i18n/translations/ja-JP.json
+++ b/i18n/translations/ja-JP.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "ダブルニーモニック",
     "Driver": "ドライバー",
     "Empty": "空",
+    "Empty passphrase": "空のパスフレーズ",
     "Enable?": "有効化?",
     "Encrypt": "暗号化",
     "Encrypted": "暗号化されました",

--- a/i18n/translations/ko-KR.json
+++ b/i18n/translations/ko-KR.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "이중 니모닉",
     "Driver": "드라이버",
     "Empty": "비어 있음",
+    "Empty passphrase": "빈 암호",
     "Enable?": "활성화?",
     "Encrypt": "암호화하다",
     "Encrypted": "암호화 후 저장",

--- a/i18n/translations/nl-NL.json
+++ b/i18n/translations/nl-NL.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Dubbel geheugensteuntje",
     "Driver": "Driver",
     "Empty": "Leeg",
+    "Empty passphrase": "Lege wachtwoordzin",
     "Enable?": "Inschakelen?",
     "Encrypt": "Versleutelen",
     "Encrypted": "Versleuteld",

--- a/i18n/translations/pt-BR.json
+++ b/i18n/translations/pt-BR.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Duplo mnemônico",
     "Driver": "Driver",
     "Empty": "Vazio",
+    "Empty passphrase": "Senha vazia",
     "Enable?": "Ativar?",
     "Encrypt": "Criptografar",
     "Encrypted": "Criptografado",

--- a/i18n/translations/ru-RU.json
+++ b/i18n/translations/ru-RU.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Двойная мнемоника",
     "Driver": "Драйвер",
     "Empty": "Пустой",
+    "Empty passphrase": "Пустая парольная фраза",
     "Enable?": "Включить?",
     "Encrypt": "Зашифровать",
     "Encrypted": "Зашифровано",

--- a/i18n/translations/tr-TR.json
+++ b/i18n/translations/tr-TR.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Çifte anımsatıcı",
     "Driver": "Sürücü",
     "Empty": "Boş",
+    "Empty passphrase": "Boş parola",
     "Enable?": "Etkinleştir?",
     "Encrypt": "Şifrele",
     "Encrypted": "Şifrelenmiş",

--- a/i18n/translations/vi-VN.json
+++ b/i18n/translations/vi-VN.json
@@ -72,6 +72,7 @@
     "Double mnemonic": "Từ gợi nhớ kép",
     "Driver": "Driver",
     "Empty": "Trống",
+    "Empty passphrase": "Cụm mật khẩu trống",
     "Enable?": "Kích hoạt?",
     "Encrypt": "Mã hóa",
     "Encrypted": "Đã mã hóa",

--- a/i18n/translations/zh-CN.json
+++ b/i18n/translations/zh-CN.json
@@ -73,6 +73,7 @@
     "Driver": "驱动程序",
     "Empty": "为空",
     "Enable?": "启用？",
+    "Empty passphrase": "空密码",
     "Encrypt": "加密",
     "Encrypted": "已加密",
     "Encrypted QR Code": "加密二维码",

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -81,6 +81,16 @@ class PassphraseEditor(Page):
             if passphrase in (ESC_KEY, MENU_EXIT):
                 return None
 
+            # if a passphrase is not set, but use press Go,
+            # the passphrase will be equal to "". This is equivalent
+            # to not having a passphrase, but is different
+            # from a None passphrase, which means no passphrase.
+            # Similarly, a passphrase with a space is not allowed.
+            if isinstance(passphrase, str) and len(passphrase) == 0:
+                self.flash_error(t("Failed to load"))
+                self.flash_error(t("Empty passphrase"))
+                return None
+
             from ..themes import theme
             from ..key import Key
 

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -246,6 +246,29 @@ def test_load_wallet_descritor_manager(mocker, amigo, tdata):
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 
 
+def test_no_passphrase_menu(mocker, amigo, tdata):
+    from krux.pages.home_pages.home import Home
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = [
+        BUTTON_ENTER,  # Proceed on message
+        BUTTON_ENTER,  # Type passphrase
+        BUTTON_PAGE_PREV,  # Move to Go (passphrase will be "")
+        BUTTON_ENTER,  # Press Go
+        BUTTON_ENTER,  # Confirm no passphrase
+    ]
+
+    FINGERPRINT_NO_PASSPHRASE = "73c5da0a"
+
+    wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+    ctx = create_ctx(mocker, BTN_SEQUENCE, wallet=wallet)
+    assert wallet.key.fingerprint == ctx.wallet.key.fingerprint
+    home = Home(ctx)
+    home.passphrase()
+    assert ctx.wallet.key.fingerprint_hex_str() == FINGERPRINT_NO_PASSPHRASE
+
+
 def test_change_passphrase_menu(mocker, amigo, tdata):
     from krux.pages.home_pages.home import Home
     from krux.wallet import Wallet


### PR DESCRIPTION
### What is this PR for?

Add a check during the customizing passphrase in the sense that make some equivalence between a `None` passphrase to `""` passphrase and not setting a new wallet when this occurs.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes


### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
