### PR TITLE
Update bdftokff.py helper script for MaixPy device fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ A new advanced utility for working with files, QRs, and manual text input. It su
 - Hide the "Change Addresses" menu option when cannot be determined by the wallet descriptor.
 - The hide mnemonic setting now ignores user confirmation when loading a mnemonic via word numbers.
 - Minor text improvements for clarity and easier translation.
+- Maixpy Fix: Increase glyphs indexing capacity affecting Amigo's translations
 
 
 # Changelog 25.03.0 - March 2025

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ FROM build-software AS build-firmware
 ARG DEVICE="maixpy_m5stickv"
 WORKDIR /src/firmware/MaixPy
 
-# overrides the DEVICE specific font.c in componets/micropython
+# overrides the DEVICE specific C files (font, sensor, ...) in componets/micropython
 RUN cp -rf projects/"${DEVICE}"/compile/overrides/. ./
 
 RUN cd projects/"${DEVICE}" && \

--- a/firmware/font/README.md
+++ b/firmware/font/README.md
@@ -6,7 +6,7 @@ To rebuild the font for all devices, run:
 poetry run python bdftokff.py True
 ```
 
-If the `True` argument was passed, the Python script will automatically overwrite the contents of the `font.c` file in each of the projects `../MaixPy/projects/*/compile/overrides/components/micropython/port/src/omv/img/font.c`, otherwise the script will produce 3 files: `m5stickv_font.c`, `amigo_font.c` and `bit_dock_yahboom_font.c`. Use these files to manually replace the contents of the `font.c` file in each of your projects.
+If the `True` argument was passed, the Python script will automatically overwrite the contents of the `font_device.h` file in each of the projects `../MaixPy/projects/*/compile/overrides/components/micropython/port/src/omv/img/include/font_device.h`, otherwise the script will produce 3 files: `m5stickv_font_device.h`, `amigo_font_device.h` and `bit_dock_yahboom_font_device.h`. Use these files to manually replace the contents of the `font_device.h` file in each of your projects.
 
 # How it works
 Krux uses bitmap fonts that are custom-built for each device it runs on. The format that the firmware expects fonts to be in is a custom format referred to as "krux font format," or `.kff`. 
@@ -35,4 +35,4 @@ To rebuild the font for all devices, run:
 ./bdftokff.sh ter-u24b 12 24 > amigo.kff
 ```
 
-Once you have `.kff` files, for each project that you want to use the updated fonts, edit `../MaixPy/projects/*/compile/overrides/components/micropython/port/src/omv/img/font.c` (substituting `maixpy_amigo` for `*` if only for an amigo) and replace the array contents in the `unicode` variable with the byte array found within the appropriate `.kff` file, then rebuild the firmware.
+Once you have `.kff` files, for each project that you want to use the updated fonts, edit `../MaixPy/projects/*/compile/overrides/components/micropython/port/src/omv/img/include/font_device.h` (substituting `maixpy_amigo` for `*` if only for an amigo) and replace the array contents in the `unicode` variable with the byte array found within the appropriate `.kff` file, then rebuild the firmware.

--- a/firmware/font/bdftokff.py
+++ b/firmware/font/bdftokff.py
@@ -106,8 +106,9 @@ def save_new_fontc(font_name, overwrite=False):
         device_name = "amigo"
 
     maixpy_path_start = "../MaixPy/projects/maixpy_"
-    maixpy_path_end = (
-        "/compile/overrides/components/micropython/port/src/omv/img/include/font_device.h"
+    maixpy_path_end = os.path.join(
+        "/compile/overrides/components/micropython/port",
+        "src/omv/img/include/font_device.h",
     )
 
     with open(filename_kff + ".kff", "r", encoding="utf-8") as read_file:

--- a/firmware/font/bdftokff.py
+++ b/firmware/font/bdftokff.py
@@ -68,10 +68,10 @@ def open_bdf_save_kff(filename, width, height):
         save_file.write(font_hex_merged)
 
     # Creates the Krux font file, to be used on each project
-    # font.c file: ../MaixPy/projects/<device_name>/compile/
-    # overrides/components/micropython/port/src/omv/img/font.c
+    # font_device.h file: ../MaixPy/projects/<device_name>/compile/
+    # overrides/components/micropython/port/src/omv/img/include/font_device.h
     # in order to replace the contents of the unicode[] variable
-    #  in the font.c
+    #  in the font_device.h
     wide_glyphs = None
     if filename in (WIDE14, WIDE16, WIDE24):
         wide_glyphs = ["ko-KR", "zh-CN", "ja-JP"]
@@ -84,9 +84,9 @@ def open_bdf_save_kff(filename, width, height):
 
 
 def save_new_fontc(font_name, overwrite=False):
-    """If overwrite=True them overwrite the content of the font.c file
+    """If overwrite=True them overwrite the content of the font_device.h file
     on each project, based on the font_name passed otherwise save
-    a new font.c file"""
+    a new font_device.h file"""
 
     filename_kff = "tiny"
     device_name = "m5stickv"
@@ -107,7 +107,7 @@ def save_new_fontc(font_name, overwrite=False):
 
     maixpy_path_start = "../MaixPy/projects/maixpy_"
     maixpy_path_end = (
-        "/compile/overrides/components/micropython/port/src/omv/img/font.c"
+        "/compile/overrides/components/micropython/port/src/omv/img/include/font_device.h"
     )
 
     with open(filename_kff + ".kff", "r", encoding="utf-8") as read_file:
@@ -148,7 +148,7 @@ def save_new_fontc(font_name, overwrite=False):
                 save_file.write(unicode_str)
     else:
         with open(
-            filename_kff + "_font.c", "w", encoding="utf-8", newline="\n"
+            filename_kff + "_font_device.h", "w", encoding="utf-8", newline="\n"
         ) as save_file:
             save_file.write(unicode_str)
 
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     open_bdf_save_kff(WIDE16, 16, 16)
     open_bdf_save_kff(WIDE24, 24, 24)
 
-    # generate new font.c files (delete kff files)
+    # generate new font_device.h files (delete kff files)
     save_new_fontc(FONT14, replace)
     save_new_fontc(FONT16, replace)
     save_new_fontc(FONT24, replace)


### PR DESCRIPTION
### What is this PR for?
Updates the helper script `firmware/font/bdftokff.py`, which is used for device font management for MaixPy.

Related to https://github.com/selfcustody/MaixPy/pull/35


### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, Amigo and Yahboom (w/ Korean font! :smile: )


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
