### PR TITLE
feat+fix: add legacy and nested-segwit types to parse_key_value_file 

### DIFF
--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -7,6 +7,7 @@ def tdata(mocker):
     import binascii
     from collections import namedtuple
     from ur.ur import UR
+    from krux.bbqr import encode_bbqr
     from embit.networks import NETWORKS
     from krux.key import (
         Key,
@@ -101,9 +102,47 @@ def tdata(mocker):
 
     SPECTER_MULTISIG_LEGACY_DESCRIPTOR = "sh(sortedmulti(2,[d3a80c8b/45h/2]xpub6ApMSMmLpzeYTv72drQnbXkzg1nedyDQVyvtZVUWCS3B1pSSp24Y1tDtzcnD1ovCBhb3QuhYtN5rE8ayoZ3c2fNBYYmPN9VQVSNTKKFe8SH/<0;1>/*,[55f8fc5d/45h/0]xpub6Ac49WroT3nhb4uicbE5EUD7WiH2Xooubauvqw5fJYTLbmWFHnGjXRXwkPnFcTgK47KzzKTJNcjua2PisceZfwdoCUXYmX5Ju2v4RU2C7ps/<0;1>/*,[3e15470d/45h/1]xpub6AFDaW88dK7HvhWpHPGwGRym7h2pk8BZYjNUQ5GSkqeoGcMXC9cai7zBCwVeRFrD4wGeWkS3wSqU2jh9nEs2f5SHiM8Fa96ffce7maiKVtm/<0;1>/*))"
     SPECTER_MULTISIG_LEGACY_WALLET_DATA = '{"label": "Specter Multisig Legacy Wallet", "blockheight": 0, "descriptor": "sh(sortedmulti(2,[d3a80c8b/45h/2]xpub6ApMSMmLpzeYTv72drQnbXkzg1nedyDQVyvtZVUWCS3B1pSSp24Y1tDtzcnD1ovCBhb3QuhYtN5rE8ayoZ3c2fNBYYmPN9VQVSNTKKFe8SH/<0;1>/*,[55f8fc5d/45h/0]xpub6Ac49WroT3nhb4uicbE5EUD7WiH2Xooubauvqw5fJYTLbmWFHnGjXRXwkPnFcTgK47KzzKTJNcjua2PisceZfwdoCUXYmX5Ju2v4RU2C7ps/<0;1>/*,[3e15470d/45h/1]xpub6AFDaW88dK7HvhWpHPGwGRym7h2pk8BZYjNUQ5GSkqeoGcMXC9cai7zBCwVeRFrD4wGeWkS3wSqU2jh9nEs2f5SHiM8Fa96ffce7maiKVtm/<0;1>/*))#jnvu8ps2", "devices": [{"type": "other", "label": "Key1"}, {"type": "other", "label": "Key2"}, {"type": "other", "label": "Key3"}]}'
+    BLUEWALLET_MULTISIG_LEGACY_WALLET_DATA = """
+    # BlueWallet Multisig setup file
+    # this file contains only public keys and is safe to
+    # distribute among cosigners
+    #
+    Name: BlueWallet Multisig Wallet
+    Policy: 2 of 3
+    Derivation: m/45'
+    Format: P2SH
+
+    d3a80c8b:
+    xpub6ApMSMmLpzeYTv72drQnbXkzg1nedyDQVyvtZVUWCS3B1pSSp24Y1tDtzcnD1ovCBhb3QuhYtN5rE8ayoZ3c2fNBYYmPN9VQVSNTKKFe8SH
+    
+    55f8fc5d:
+    xpub6Ac49WroT3nhb4uicbE5EUD7WiH2Xooubauvqw5fJYTLbmWFHnGjXRXwkPnFcTgK47KzzKTJNcjua2PisceZfwdoCUXYmX5Ju2v4RU2C7ps
+
+    3e15470d:
+    xpub6AFDaW88dK7HvhWpHPGwGRym7h2pk8BZYjNUQ5GSkqeoGcMXC9cai7zBCwVeRFrD4wGeWkS3wSqU2jh9nEs2f5SHiM8Fa96ffce7maiKVtm
+    """
 
     SPECTER_MULTISIG_NESTED_DESCRIPTOR = "sh(wsh(sortedmulti(2,[55f8fc5d/48h/0h/0h/1h]xpub6EKmKYGYc1WY3XTWp59sdZrAHGs7mB9dszpwtKBcS1icCfWiYqtGgmgQmm6emkQdSFCiTmX5bpQiMbt8rPsb7D6Skqsr1SeJcffkEHE4358/<0;1>/*,[3e15470d/48h/0h/0h/1h]xpub6F2P6Pz5KLPgBu5k6kU8H9KGtYSqciCd9HQ7Jb7NNwNbThBw3NufvSoVJdMeJFR5ABQy1EHtSFJsDbuwSt3HXmUHRWqY3qc8jdoLYuvYKBg/<0;1>/*,[d3a80c8b/48h/0h/0h/1h]xpub6FKYY6y3oVi7hCKgx5i4Gv4u3SMoVrVAYJ1JPt2PJ1YQeyYFwNzar2idv5URtdMD6hApqQGyuh5qz1mDnaHddVjspGAbdyBSeGAyq4jjRAk/<0;1>/*)))"
     SPECTER_MULTISIG_NESTED_WALLET_DATA = '{"label": "Specter Multisig Nested Wallet", "blockheight": 0, "descriptor": "sh(wsh(sortedmulti(2,[55f8fc5d/48h/0h/0h/1h]xpub6EKmKYGYc1WY3XTWp59sdZrAHGs7mB9dszpwtKBcS1icCfWiYqtGgmgQmm6emkQdSFCiTmX5bpQiMbt8rPsb7D6Skqsr1SeJcffkEHE4358/<0;1>/*,[3e15470d/48h/0h/0h/1h]xpub6F2P6Pz5KLPgBu5k6kU8H9KGtYSqciCd9HQ7Jb7NNwNbThBw3NufvSoVJdMeJFR5ABQy1EHtSFJsDbuwSt3HXmUHRWqY3qc8jdoLYuvYKBg/<0;1>/*,[d3a80c8b/48h/0h/0h/1h]xpub6FKYY6y3oVi7hCKgx5i4Gv4u3SMoVrVAYJ1JPt2PJ1YQeyYFwNzar2idv5URtdMD6hApqQGyuh5qz1mDnaHddVjspGAbdyBSeGAyq4jjRAk/<0;1>/*)))#dlkhjss4", "devices": [{"type": "other", "label": "Key1"}, {"type": "other", "label": "Key2"}, {"type": "other", "label": "Key3"}]}'
+    BLUEWALLET_MULTISIG_NESTED_WALLET_DATA = """
+    # BlueWallet Multisig setup file
+    # this file contains only public keys and is safe to
+    # distribute among cosigners
+    #
+    Name: BlueWallet Multisig Wallet
+    Policy: 2 of 3
+    Derivation: m/48'/0'/0'/1'
+    Format: P2SH-P2WSH
+
+    55f8fc5d:
+    xpub6EKmKYGYc1WY3XTWp59sdZrAHGs7mB9dszpwtKBcS1icCfWiYqtGgmgQmm6emkQdSFCiTmX5bpQiMbt8rPsb7D6Skqsr1SeJcffkEHE4358
+
+    3e15470d:
+    xpub6F2P6Pz5KLPgBu5k6kU8H9KGtYSqciCd9HQ7Jb7NNwNbThBw3NufvSoVJdMeJFR5ABQy1EHtSFJsDbuwSt3HXmUHRWqY3qc8jdoLYuvYKBg
+
+    d3a80c8b:
+    xpub6FKYY6y3oVi7hCKgx5i4Gv4u3SMoVrVAYJ1JPt2PJ1YQeyYFwNzar2idv5URtdMD6hApqQGyuh5qz1mDnaHddVjspGAbdyBSeGAyq4jjRAk
+    """
 
     SPECTER_MULTISIG_DESCRIPTOR = "wsh(sortedmulti(2,[55f8fc5d/48h/0h/0h/2h]xpub6EKmKYGYc1WY6t9d3d9SksR8keSaPZbFa6tqsGiH4xVxx8d2YyxSX7WG6yXEX3CmG54dPCxaapDw1XsjwCmfoqP7tbsAeqMVfKvqSAu4ndy/0/*,[3e15470d/48h/0h/0h/2h]xpub6F2P6Pz5KLPgCc6pTBd2xxCunaSYWc8CdkL28W5z15pJrN3aCYY7mCUAkCMtqrgT2wdhAGgRnJxAkCCUpGKoXKxQ57yffEGmPwtYA3DEXwu/0/*,[d3a80c8b/48h/0h/0h/2h]xpub6FKYY6y3oVi7ihSCszFKRSeZj5SzrfSsUFXhKqjMV4iigrLhxwMX3mrjioNyLTZ5iD3u4wU9S3tyzpJGxhd5geaXoQ68jGz2M6dfh2zJrUv/0/*))"
     SPECTER_MULTISIG_WALLET_DATA = '{"label": "Specter Multisig Wallet", "blockheight": 0, "descriptor": "wsh(sortedmulti(2,[55f8fc5d/48h/0h/0h/2h]xpub6EKmKYGYc1WY6t9d3d9SksR8keSaPZbFa6tqsGiH4xVxx8d2YyxSX7WG6yXEX3CmG54dPCxaapDw1XsjwCmfoqP7tbsAeqMVfKvqSAu4ndy/0/*,[3e15470d/48h/0h/0h/2h]xpub6F2P6Pz5KLPgCc6pTBd2xxCunaSYWc8CdkL28W5z15pJrN3aCYY7mCUAkCMtqrgT2wdhAGgRnJxAkCCUpGKoXKxQ57yffEGmPwtYA3DEXwu/0/*,[d3a80c8b/48h/0h/0h/2h]xpub6FKYY6y3oVi7ihSCszFKRSeZj5SzrfSsUFXhKqjMV4iigrLhxwMX3mrjioNyLTZ5iD3u4wU9S3tyzpJGxhd5geaXoQ68jGz2M6dfh2zJrUv/0/*))#3nfc6jdy", "devices": [{"type": "other", "label": "Key1"}, {"type": "other", "label": "Key2"}, {"type": "other", "label": "Key3"}]}'
@@ -270,6 +309,8 @@ def tdata(mocker):
             "BLUEWALLET_MULTISIG_WALLET_DATA_INVALID_SCRIPT",
             "BLUEWALLET_MULTISIG_WALLET_DATA_INVALID_KEYS",
             "BLUEWALLET_MULTISIG_WALLET_DATA_MISSING_KEYS",
+            "BLUEWALLET_MULTISIG_LEGACY_WALLET_DATA",
+            "BLUEWALLET_MULTISIG_NESTED_WALLET_DATA",
             "UR_OUTPUT_MULTISIG_DESCRIPTOR",
             "UR_OUTPUT_MULTISIG_WALLET_DATA",
             "UR_BYTES_MULTISIG_DESCRIPTOR",
@@ -337,6 +378,8 @@ def tdata(mocker):
         BLUEWALLET_MULTISIG_WALLET_DATA_INVALID_SCRIPT,
         BLUEWALLET_MULTISIG_WALLET_DATA_INVALID_KEYS,
         BLUEWALLET_MULTISIG_WALLET_DATA_MISSING_KEYS,
+        BLUEWALLET_MULTISIG_LEGACY_WALLET_DATA,
+        BLUEWALLET_MULTISIG_NESTED_WALLET_DATA,
         UR_OUTPUT_MULTISIG_DESCRIPTOR,
         UR_OUTPUT_MULTISIG_WALLET_DATA,
         UR_BYTES_MULTISIG_DESCRIPTOR,
@@ -624,16 +667,44 @@ def test_is_loaded(mocker, m5stickv, tdata):
 
 def test_wallet_qr(mocker, m5stickv, tdata):
     from krux.wallet import Wallet
-    from krux.qr import FORMAT_UR
+    from krux.bbqr import encode_bbqr
+    from krux.qr import FORMAT_UR, FORMAT_BBQR
 
-    for wallet in (Wallet(tdata.MULTISIG_NATIVE_SW_1), Wallet(None)):
-        wallet.wallet_data = tdata.UR_OUTPUT_MULTISIG_WALLET_DATA
-        wallet.wallet_qr_format = FORMAT_UR
+    cases = [
+        (
+            Wallet(None),
+            tdata.UR_OUTPUT_MULTISIG_WALLET_DATA,
+            FORMAT_UR,
+            None,  # No need to check a different wallet data
+        ),
+        (
+            Wallet(tdata.MULTISIG_NATIVE_SW_1),
+            tdata.UR_OUTPUT_MULTISIG_WALLET_DATA,
+            FORMAT_UR,
+            None,  # No need to check a different wallet data
+        ),
+        (
+            Wallet(tdata.MINISCRIPT_KEY),
+            tdata.LIANA_MINISCRIPT_DESCRIPTOR,
+            FORMAT_BBQR,
+            encode_bbqr(tdata.LIANA_MINISCRIPT_DESCRIPTOR, file_type="U").payload,
+        ),
+    ]
 
-        wallet_data, wallet_qr_format = wallet.wallet_qr()
+    n = 0
+    for case in cases:
+        print(f"Case {n}")
+        case[0].wallet_data = case[1]
+        case[0].wallet_qr_format = case[2]
 
-        assert wallet_data == tdata.UR_OUTPUT_MULTISIG_WALLET_DATA
-        assert wallet_qr_format == FORMAT_UR
+        wallet_data, wallet_qr_format = case[0].wallet_qr()
+
+        if case[3] is not None:
+            assert wallet_data.payload == case[3]
+        else:
+            assert wallet_data == case[1]
+        assert wallet_qr_format == case[2]
+        n += 1
 
 
 def test_receive_addresses(mocker, m5stickv, tdata):
@@ -710,7 +781,7 @@ def test_receive_addresses(mocker, m5stickv, tdata):
                 "bc1p8fue49l0amhqvsau72gmk3dau2w5ktxkh2njck95rej0v538wj4q40gksu",
             ],
         ),
-        (  # Multisig SH
+        (  # Multisig SH - specter file
             tdata.MULTISIG_LEGACY_1,
             tdata.SPECTER_MULTISIG_LEGACY_WALLET_DATA,
             FORMAT_PMOFN,
@@ -727,9 +798,43 @@ def test_receive_addresses(mocker, m5stickv, tdata):
                 "3JTktva4VHGtWw4bqi7nXjgzXxCi6fVpaK",
             ],
         ),
-        (  # Multisig SH(WSH)
+        (  # Multisig SH - BlueWallet file
+            tdata.MULTISIG_LEGACY_1,
+            tdata.BLUEWALLET_MULTISIG_LEGACY_WALLET_DATA,
+            FORMAT_PMOFN,
+            [
+                "35x9JGy14Kbeg9PsKA7gYRe3FHLvZEdzhL",
+                "3QX687SLmE7CvEy4k6y1GnCRA7syxbkRxg",
+                "3PzCCFhmqvmzcPnsQR4W6WNiYDNXPSuM8k",
+                "34esbYLwuLvtxWHbFfnUZ8Ckg2WuHgh9d9",
+                "38YMXxGP4wLZw9ttDLEq9jnvbY3VzJDSMt",
+                "31p7jB2RUm4Xk17QA5QxXH3dM8z6bxpuEQ",
+                "37Gvz2hmRpMFKtsDcxPJg2dY9z4VzYezxq",
+                "3F9jXMGpdFHeXFDTNdA3nfeKFoWHmXBVHC",
+                "3BwdEUXVeLTaupo69VqFYtqwEkSt56eWYa",
+                "3JTktva4VHGtWw4bqi7nXjgzXxCi6fVpaK",
+            ],
+        ),
+        (  # Multisig SH(WSH) - specter file
             tdata.MULTISIG_NESTED_SW_1,
             tdata.SPECTER_MULTISIG_NESTED_WALLET_DATA,
+            FORMAT_PMOFN,
+            [
+                "35mT8c3vLU67Jt1BFiSgrGCikHK2f2uQgd",
+                "3Py5yzBjtizbM3W8rPfSsxGR4KtRkLz1c7",
+                "324LHbwGnuTEH4SXTKQBqviA5sH7Wbc9Fn",
+                "3JgRAi3i16xiCEai2DzSuRLcGhbdYsBUkL",
+                "3H96EHfZDhptHUTNdkYJqKLUSTMdA72uSm",
+                "3NKeGbnpCYTiTruBCmYxd4uhvdRCyv7fY9",
+                "3BJW8AiaW1SE8UjxPxGiRd18TjAJbRfvWS",
+                "3CrbeMR8AqwH4ZhQSGvFgExPrVgFzRxH1t",
+                "3JSQH4pSoP4mgcu9d4QW2cRewCruygkJyu",
+                "3MPeeu19HzPGJ9xssekTR2epLn3CFFKvEP",
+            ],
+        ),
+        (  # Multisig SH(WSH) - BlueWallet file
+            tdata.MULTISIG_NESTED_SW_1,
+            tdata.BLUEWALLET_MULTISIG_NESTED_WALLET_DATA,
             FORMAT_PMOFN,
             [
                 "35mT8c3vLU67Jt1BFiSgrGCikHK2f2uQgd",


### PR DESCRIPTION
### What is this PR for?

- Add P2SH, P2SH_P2WSH to wallet data keys using INI format
(like in bluewallet) and removes the assumption of a native segwit at
the end of the method because it's potentially unreachable with
bluewallet UI flow -- this line only could be reachable if using a
multisig 1-of-1 described in a INI file.

- cover some cases like exporting `wallet_qr` to BBQR format.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
