### PR TITLE
Disable check for KEF in normal PSBT flow

### DIFF
--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -457,16 +457,17 @@ class Home(Page):
             self.flash_error(t("Failed to load"))
             return MENU_CONTINUE
 
-        try:
-            from ..encryption_ui import decrypt_kef
-
-            data = decrypt_kef(self.ctx, data)
-        except KeyError:
-            self.flash_error(t("Failed to decrypt"))
-            return MENU_CONTINUE
-        except ValueError:
-            # ValueError=not KEF or declined to decrypt
-            pass
+        # DISABLED to avoid false "Decrypt?" on normal PSBTs as KEF
+        # try:
+        #     from ..encryption_ui import decrypt_kef
+        #
+        #     data = decrypt_kef(self.ctx, data)
+        # except KeyError:
+        #     self.flash_error(t("Failed to decrypt"))
+        #     return MENU_CONTINUE
+        # except ValueError:
+        #     # ValueError=not KEF or declined to decrypt
+        #     pass
 
         # PSBT read OK! Will try to sign
         self.ctx.display.clear()

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -568,7 +568,7 @@ def test_load_sign_psbt_menu(mocker, amigo, tdata):
         getattr(home_method, _method[1])()
 
 
-def test_sign_psbt_fails_on_decrypt_kef_key_error(mocker, m5stickv, tdata):
+def DISABLEDtest_sign_psbt_fails_on_decrypt_kef_key_error(mocker, m5stickv, tdata):
     from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
     from krux.pages.home_pages.home import Home
     from krux.wallet import Wallet


### PR DESCRIPTION
### What is this PR for?

Because a normal PSBT might appear as a KEF envelope,
* whenever binary or after base64.decode(), the 72nd byte is a valid KEF version,
* and the length of the PSBT is such that kef.unwrap() succeeds to parse
It is believed that the order of processing should be NOT to check for KEF first, but to try to parse the PSBT and only after failure to check for a KEF envelope.  However, this is more complicated and time-consuming than ideal at this moment where a new beta is needed.

Therefore, this PR simply disables the possibility of normal krux offering to decrypt a KEF envelope that is a PSBT.

It could still be done via:
* User encrypts a PSBT in DatumTool, saves that KEF as a QR video or to SD,
* User later decrypts the KEF QR or file within DatumTool, exports decrypted PSBT as a QR to another krux device or saves PSBT to SD.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
