### PR TITLE
Loading Data: fall-back to KEF

### DIFF
--- a/src/krux/kef.py
+++ b/src/krux/kef.py
@@ -502,15 +502,6 @@ def unwrap(kef_bytes):
             raise ValueError("Ciphertext is not aligned")
     if len(payload) < extra + 1:
         raise ValueError("Ciphertext is too short")
-    
-    # TODO: consider better probabilistic strategies to rule-out KEF identification
-    # cipher payload should appear random
-    if len(payload) > 32:
-        upper128 = len([x for x in payload if x > 127])
-        if upper128 == 0:
-            raise ValueError("Payload is ascii")
-        if upper128 < len(payload) * 0.001:
-            raise ValueError("Distribution of payload not uniform")
 
     return (id_, version, iterations, payload)
 

--- a/src/krux/kef.py
+++ b/src/krux/kef.py
@@ -500,8 +500,17 @@ def unwrap(kef_bytes):
     if VERSIONS[version].get("pkcs_pad", False) in (True, False):
         if (len(payload) - extra) % 16 != 0:
             raise ValueError("Ciphertext is not aligned")
-        if (len(payload) - extra) // 16 < 1:
-            raise ValueError("Ciphertext is too short")
+    if len(payload) < extra + 1:
+        raise ValueError("Ciphertext is too short")
+    
+    # TODO: consider better probabilistic strategies to rule-out KEF identification
+    # cipher payload should appear random
+    if len(payload) > 32:
+        upper128 = len([x for x in payload if x > 127])
+        if upper128 == 0:
+            raise ValueError("Payload is ascii")
+        if upper128 < len(payload) * 0.001:
+            raise ValueError("Distribution of payload not uniform")
 
     return (id_, version, iterations, payload)
 

--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -283,7 +283,6 @@ class Addresses(Page):
     def scan_address(self, addr_type=0):
         """Handler for the 'receive' or 'change' menu item"""
         from ..qr_capture import QRCodeCapture
-        from ..encryption_ui import decrypt_kef
 
         qr_capture = QRCodeCapture(self.ctx)
         data, qr_format = qr_capture.qr_capture_loop()
@@ -291,21 +290,34 @@ class Addresses(Page):
             self.flash_error(t("Failed to load"))
             return MENU_CONTINUE
 
-        try:
-            data = decrypt_kef(self.ctx, data).decode()
-        except KeyError:
-            self.flash_error(t("Failed to decrypt"))
-            return MENU_CONTINUE
-        except ValueError:
-            # ValueError=not KEF or declined to decrypt
-            pass
+        from ...wallet import parse_address
 
         addr = None
         try:
-            from ...wallet import parse_address
-
             addr = parse_address(data)
         except:
+            pass
+
+        if addr is None:
+            from ..encryption_ui import decrypt_kef
+
+            try:
+                data = decrypt_kef(self.ctx, data).decode()
+            except ValueError:
+                # ValueError=not KEF or declined to decrypt
+                data = None
+            except:
+                # KeyError or other exception during decryption
+                self.flash_error(t("Failed to decrypt"))
+                return MENU_CONTINUE
+
+            if data is not None:
+                try:
+                    addr = parse_address(data)
+                except:
+                    pass
+
+        if addr is None:
             self.flash_error(t("Invalid address"))
             return MENU_CONTINUE
 

--- a/tests/test_kef.py
+++ b/tests/test_kef.py
@@ -935,7 +935,7 @@ def test_wrapper_interpretation_of_iterations(m5stickv):
     # mock values so that iterations will be at bytes[6:9]
     id_ = b"test"
     version = 0
-    ciphertext = bytes([x*8 for x in range(32)])
+    ciphertext = bytes([x * 8 for x in range(32)])
 
     # if (iterations % 10000 == 0) they are serialized divided by 10000
     for iterations in (ten_k, ten_k * 10, ten_k * 50, ten_k * ten_k):

--- a/tests/test_kef.py
+++ b/tests/test_kef.py
@@ -935,7 +935,7 @@ def test_wrapper_interpretation_of_iterations(m5stickv):
     # mock values so that iterations will be at bytes[6:9]
     id_ = b"test"
     version = 0
-    ciphertext = b"\x00" * 32
+    ciphertext = bytes([x*8 for x in range(32)])
 
     # if (iterations % 10000 == 0) they are serialized divided by 10000
     for iterations in (ten_k, ten_k * 10, ten_k * 50, ten_k * ten_k):


### PR DESCRIPTION
DRAFT: For a future release AFTER v25.09.0

### What is this PR for?

Focus of this PR is to re-prioritize loading of data (scanned or from sd) to be treated as plaintext, within context, instead of first attempting to parse and decrypt a KEF envelope. PSBTs in particular, which are often loaded in binary, form can appear to be KEF, but if they can be parsed as PSBTs first, then user will not have to answer "No".  If parsing fails, in this case -- as a PSBT, we could then fall-back to see if it was KEF, and try again after decryption.

Loading of datum-types TO DO:
- [x] addresses
- [x] descriptors
- [ ] messages to be signed
- [ ] PSBTs

In some cases, this is not possible, a KEF must be checked first, in cases where data is treated as random bytes
and no other obvious parsing could be done... ie) for mnemonic entropy, passphrases, and for decryption keys we
should check if it's a KEF first (rather than treating 32 bytes as a mnemonic, or base43 text as a passphrase, or a string of bytes as the decryption key when in fact these would normally parse as kef envelopes to prompt decryption... and in the case of a false-KEF the user will know NOT to decrypt.

In most other cases, we could try to parse in plaintext form first, and then fall back to trying KEF if it fails.

### Changes made to:
- [x] Code
- [x] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
