### PR TITLE
Input.<button>_value() methods feed watchdog

### DIFF
--- a/src/krux/input.py
+++ b/src/krux/input.py
@@ -128,18 +128,21 @@ class Input:
     def enter_value(self):
         """Intermediary method to pull button ENTER state"""
         if self.enter is not None:
+            self.wdt_feed_inc_entropy()
             return self.enter.value()
         return RELEASED
 
     def page_value(self):
         """Intermediary method to pull button PAGE state"""
         if self.page is not None:
+            self.wdt_feed_inc_entropy()
             return self.page.value()
         return RELEASED
 
     def page_prev_value(self):
         """Intermediary method to pull button PAGE_PREV state"""
         if self.page_prev is not None:
+            self.wdt_feed_inc_entropy()
             return self.page_prev.value()
         return RELEASED
 


### PR DESCRIPTION

### What is this PR for?  
For cases where fast_forward is implemented with while loops and timing outside of Input class, this pr
feeds the watchdog in case the button is pressed for a long time... like when fast-forwarding thru tinyseed screen.



### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, Amigo, yahboom_devkit


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other (a delayed bug-fix pr to pr_703, where I haven't yet found a better fix).
