### PR TITLE
removes a long list of "# pylint disable:" errors and warnings

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -1,6 +1,5 @@
 # The MIT License (MIT)
 
-# pylint: disable=C0103,C0116,C0206,C0302,E0601,R0912,R0914,W0212,W0612,W0613
 
 # Copyright (c) 2021-2024 Krux contributors
 


### PR DESCRIPTION
### What is this PR for?

This pr removes unintentionally-left-behind pylint error/warning disablers at the top of src/krux/pages/login.py

This was an oversight that I left behind from early kef integration -- and was a pattern I used extensively, just to make progress early on.  I have done a search of similar for the entire codebase; short pylint-disablers are exceptional rather than the rule.

### Changes made to:
- [x] Code (pylint disablers removed)
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
