### PR TITLE
Test missing cases for fast_forward or backward

### DIFF
--- a/krux
+++ b/krux
@@ -86,11 +86,13 @@ if [ "$1" == "build" ]; then
             echo "Wrong or unsupported device name, use maixpy_devicename"
         fi
     fi
-elif [ "$1" == "flash" -o "$1" == "boot" ]; then
+elif [ "$1" == "flash" -o "$1" == "boot" -o "$1" == "erase" ]; then
     if [ "$1" == "flash" ]; then
         CMD_SUFFIX="kboot.kfpkg"
-    else
+    elif [ "$1" == "boot" ]; then
         CMD_SUFFIX="-s firmware.bin"
+    else
+        CMD_SUFFIX="-E"
     fi
     device="$2"
     if [ -z "$device" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,10 +133,17 @@ git-update = "git submodule update --init --recursive"
 git-pull = "git pull git@github.com:selfcustody/krux.git"
 git-pull-https = "git pull https://github.com/selfcustody/krux.git"
 
-# flash tasks
-flash-cmd = "python firmware/Kboot/build/ktool.py -b 2000000 build/kboot.kfpkg"
+# ktool tasks 
+ktool-cmd = "python firmware/Kboot/build/ktool.py -b 2000000"
+flash-cmd.ref = "ktool-cmd build/kboot.kfpkg"
 flash.ref = "flash-cmd -B goE"
 flash-dock.ref = "flash-cmd -B dan"
+boot-cmd.ref = "ktool-cmd -s build/firmware.bin"
+boot.ref = "boot-cmd -B goE"
+boot-dock.ref = "boot-cmd -B dan"
+terminal.ref = "ktool-cmd -T" # for yahboom add param: --reset
+erase.ref = "ktool-cmd -B goE -E"
+erase-dock.ref = "ktool-cmd -B dan -E"
 
 # task for bdftokff font glyphs update
 update-glyphs = "python ./firmware/font/bdftokff.py True"

--- a/tests/pages/test_datum_tool.py
+++ b/tests/pages/test_datum_tool.py
@@ -1047,3 +1047,30 @@ def test_datumtool_view_contents(m5stickv, mocker, mock_file_operations):
     page.contents = some_bytes
     page.view_contents()
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
+def test_datumtool_show_contents_button_turbo(mocker, m5stickv):
+    from krux.pages.datum_tool import DatumTool
+    from krux.input import PRESSED, BUTTON_ENTER, KEY_REPEAT_DELAY_MS
+    import time
+
+    ctx = create_ctx(mocker, [BUTTON_ENTER, BUTTON_ENTER])
+    datum = DatumTool(ctx)
+    datum.contents = "testing 123 " * 250
+
+    mocker.patch("time.sleep_ms", new=mocker.MagicMock())
+
+    # fast forward
+    ctx.input.page_value = mocker.MagicMock(side_effect=[PRESSED, None])
+
+    datum._show_contents()
+
+    time.sleep_ms.assert_called_with(KEY_REPEAT_DELAY_MS)
+
+    # fast backward
+    ctx.input.page_value = mocker.MagicMock(return_value=None)
+    ctx.input.page_prev_value = mocker.MagicMock(side_effect=[PRESSED, None])
+
+    datum._show_contents()
+
+    time.sleep_ms.assert_called_with(KEY_REPEAT_DELAY_MS)

--- a/tests/pages/test_keypads.py
+++ b/tests/pages/test_keypads.py
@@ -1,0 +1,21 @@
+from . import create_ctx
+import pytest
+
+
+def test_button_turbo(mocker, m5stickv):
+    from krux.pages.keypads import Keypad
+    from krux.input import FAST_FORWARD, FAST_BACKWARD, PRESSED
+
+    ctx = create_ctx(mocker, [])
+    keypad = Keypad(ctx, "abc")
+    mocker.spy(keypad, "_next_key")
+    mocker.spy(keypad, "_previous_key")
+    ctx.input.page_value = mocker.MagicMock(side_effect=[PRESSED, None])
+
+    keypad.navigate(FAST_FORWARD)
+    keypad._next_key.assert_called()
+
+    ctx.input.page_value = mocker.MagicMock(side_effect=None)
+    ctx.input.page_prev_value = mocker.MagicMock(side_effect=[PRESSED, None])
+    keypad.navigate(FAST_BACKWARD)
+    keypad._previous_key.assert_called()

--- a/tests/pages/test_stackbit.py
+++ b/tests/pages/test_stackbit.py
@@ -151,3 +151,30 @@ def test_esc_entering_stackbit(amigo, mocker):
 
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     assert words == None
+
+
+def test_entering_stackbit_buttons_turbo(mocker, m5stickv):
+    from krux.pages.stack_1248 import Stackbit
+    from krux.input import PRESSED, FAST_FORWARD, FAST_BACKWARD
+    import pytest
+
+    ctx = create_ctx(mocker, [])
+    stackbit = Stackbit(ctx)
+    stackbit.index = mocker.MagicMock(side_effect=ValueError)
+
+    # fast forward
+    ctx.input.page_value = mocker.MagicMock(return_value=PRESSED)
+
+    with pytest.raises(ValueError):
+        stackbit.enter_1248()
+
+    stackbit.index.assert_called_with(0, FAST_FORWARD)
+
+    # fast backward
+    ctx.input.page_value = mocker.MagicMock(return_value=None)
+    ctx.input.page_prev_value = mocker.MagicMock(return_value=PRESSED)
+
+    with pytest.raises(ValueError):
+        stackbit.enter_1248()
+
+    stackbit.index.assert_called_with(0, FAST_BACKWARD)

--- a/tests/pages/test_tiny_seed.py
+++ b/tests/pages/test_tiny_seed.py
@@ -101,10 +101,10 @@ def test_enter_tiny_seed_button_turbo(mocker, m5stickv):
 
     ctx = create_ctx(mocker, [])
     tiny_seed = TinySeed(ctx)
+    tiny_seed._new_index = mocker.MagicMock(side_effect=ValueError)
 
     # fast forward
     ctx.input.page_value = mocker.MagicMock(return_value=PRESSED)
-    tiny_seed._new_index = mocker.MagicMock(side_effect=ValueError)
     with pytest.raises(ValueError):
         tiny_seed.enter_tiny_seed()
 


### PR DESCRIPTION
### What is this PR for?
- `tests/pages/test_datum_tool.py`: new tests for FAST_FORWARD / BACKWARD
- `tests/pages/test_stackbit.py`: new tests for FAST_FORWARD / BACKWARD
- New file `tests/pages/test_keypads.py`
- Krux script: added erase option
- Poetry poe: added tasks for flash, boot, terminal and erase


### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
