### PR TITLE
maixpy_yahboom_devkit support via krux script

### DIFF
--- a/krux
+++ b/krux
@@ -67,6 +67,7 @@ if [ "$1" == "build" ]; then
         [ "$device" == "maixpy_yahboom" ]||
         [ "$device" == "maixpy_cube" ]||
         [ "$device" == "maixpy_wonder_mv" ]||
+        [ "$device" == "maixpy_yahboom_devkit" ]||
         [ "$device" == "maixpy_tzt" ]||
         [ "$device" == "maixpy_wonder_k" ]||
         [ "$allow_unsupported" ]; then
@@ -114,6 +115,7 @@ elif [ "$1" == "flash" -o "$1" == "boot" -o "$1" == "erase" ]; then
         elif [ "$device" == "maixpy_dock" ]||
         [ "$device" == "maixpy_yahboom" ]||
         [ "$device" == "maixpy_wonder_mv" ]||
+        [ "$device" == "maixpy_yahboom_devkit" ]||
         [ "$device" == "maixpy_wonder_k" ]; then
             # https://devicehunt.com/view/type/usb/vendor/1a86/device/7523
             device_vendor_product_id="1a86:7523"


### PR DESCRIPTION
### What is this PR for?
The "Yahboom K210 Developer Kit" has been built with the '--unsuported' flag since late 2024, and was flashed like maixpy_yahboom previously.

Since unsupported boards will not be included in releases, this pr inserts support for the maixpy_yahboom_devkit in a way that chronologically preserves how old or how new this board is (after wonder_mv support, before tzt support).  Can now simply `./krux build maixpy_yahboom_devkit` (and `./krux boot maixpy_yahboom_devkit` breaking out of terminal to try it out), then `./krux flash maixpy_yahboom_devkit` to flash the board if all seems well.

The `--unsupported` flag and logic was NOT removed.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, built and tested on maixpy_yahboom_devkit

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
