### PR TITLE
discontinue Maix Bit releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ From the wonderful land of Korea, a new creation arrives: the WonderK PRO. Creat
 ### Code optimization
 Reduced firmware size by 25% and lowered RAM usage through code cleanup and optimizations.
 
+### Discontinued Support for Maix Bit Device
+The Maix Bit device has long been discouraged due to its poor-quality camera. Starting with this release, we are discontinuing support and it will no longer be included in future builds. The support and parameters for building its firmware from source, however, will be kept.
+
 # Changelog 25.09.0 - September 2025
 
 ### Extended Encryption Options

--- a/docs/getting-started/installing/from-pre-built-release.en.md
+++ b/docs/getting-started/installing/from-pre-built-release.en.md
@@ -36,7 +36,7 @@ Extract the latest version of Krux you downloaded and enter the folder:
 unzip {{latest_krux}}.zip && cd {{latest_krux}}
 ```
 
-Connect the device to your computer via USB (for Maix Amigo, make sure you’re using bottom port), power it on, and run the following, replacing `DEVICE` with either `m5stickv`, `amigo`, `bit`, `cube` or `yahboom` (to Yahboom you may need to manually specify the port, for example `/dev/ttyUSB0` on Linux or `COM6` on Windows):
+Connect the device to your computer via USB (for Maix Amigo, make sure you’re using bottom port), power it on, and run the following, replacing `DEVICE` with either `m5stickv`, `amigo`, `cube` or `yahboom` (to Yahboom you may need to manually specify the port, for example `/dev/ttyUSB0` on Linux or `COM6` on Windows):
 ```bash
 ./ktool -B goE -b 1500000 maixpy_DEVICE/kboot.kfpkg
 ```
@@ -59,7 +59,7 @@ If `ktool` fails to run, you may need to give it executable permissions with `ch
 
 If the flashing process fails midway through, check the connection, restart the device, and try the command again.
 
-Two serial ports are created when `Amigo` and `Bit` are connected to a PC. Sometimes Ktool will pick the wrong port and flashing will fail. Manually specify the serial port to overcome this issue using `-p` argument:
+Two serial ports are created when `Amigo` are connected to a PC. Sometimes Ktool will pick the wrong port and flashing will fail. Manually specify the serial port to overcome this issue using `-p` argument:
 
 ##### Linux
 See the correct port using `ls /dev/ttyUSB*`, in the example below we use `/dev/ttyUSB0`:

--- a/docs/getting-started/installing/from-source.en.md
+++ b/docs/getting-started/installing/from-source.en.md
@@ -65,7 +65,7 @@ unzip kboot.kfpkg -d ./kboot/
 ```
 
 ### Flash the firmware onto the device
-Connect the device to your computer via USB (for Maix Amigo, make sure you’re using bottom port), power it on, and run the following, replacing `DEVICE` with either `m5stickv`, `amigo`, `bit`, `cube`, `dock`, `yahboom` or `wonder_mv`:
+Connect the device to your computer via USB (for Maix Amigo, make sure you’re using bottom port), power it on, and run the following, replacing `DEVICE` with either `m5stickv`, `amigo`, `cube`, `dock`, `yahboom` or `wonder_mv`:
 ```bash
 # flash firmware to DEVICE
 ./krux flash maixpy_DEVICE

--- a/docs/getting-started/installing/from-test-release.en.md
+++ b/docs/getting-started/installing/from-test-release.en.md
@@ -50,24 +50,6 @@ To Flash Maix Amigo run the following.
 amigo-more-info-faq.en.txt
 ----8<----
 
-#### Sipeed Maix Bit
-To Flash Maix Bit run the following.
-
-##### Linux
-```bash
-./ktool-linux -B goE -b 1500000 maixpy_bit/kboot.kfpkg
-```
-
-##### Mac
-```bash
-./ktool-mac -B goE -b 1500000 maixpy_bit/kboot.kfpkg
-```
-
-##### Windows
-```pwsh
-.\ktool-win.exe -B goE -b 1500000 maixpy_bit\kboot.kfpkg
-```
-
 #### Sipeed Maix Cube
 To Flash Maix Cube run the following.
 

--- a/docs/parts.en.md
+++ b/docs/parts.en.md
@@ -2,17 +2,17 @@
 
 ### Compatible Devices (comparative table)
 
-| Device | [M5StickV](#m5stickv) | [Maix Amigo](#maix-amigo) | [Maix Dock](#maix-dock-and-maix-bit) | [Maix Bit](#maix-dock-and-maix-bit) | [Yahboom k210 module](#yahboom-k210-module) | [Maix Cube](#maix-cube) | [WonderMV](#wondermv) |
-| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
-| Price range | US$ 50-55 | US$ 50-85 | US$ 27-35  | US$ 32-42 | US$ 45-61 | US$ 34-49 | US$ 58-86 |
-| Screen size / resolution | 1.14" / 135*240 | 3.5" / 320*480 | 2.4" / 240*320 | 2.4" / 240*320 | 2" / 240*320 | 1.3" / 240*240 | 2" / 240*320 |
-| Brightness control | :white_check_mark: | :x: | :x: | :x: | :x: | :white_check_mark: | :white_check_mark: |
-| Device size | 48\*24\*22mm | 104\*63\*17mm | 98\*59\*18mm | 69\*84\*41mm | 57\*41\*17mm | 40\*40\*16mm | 59\*41\*17mm |
-| Touchscreen | :x: | Capacitive | :x: | :x: | Capacitive | :x: | Capacitive |
-| Camera | `OV7740` | `OV7740` rear<br>`GC0328` front | `GC0328` | `OV2640` or<br>`OV5642` | `OV2640` <i style="font-size: 85%">(VER:1.0)</i> or<br>`GC2145` <i style="font-size: 85%">(VER:1.1)</i> | `OV7740` | `GC2145` |
-| Battery  | 200mAh | 520mAh | :x: | :x: | :x: | 200mAh | :x: |
-| Requirements | None | None | [Rotary encoder](https://duckduckgo.com/?q=ky-040)<br> [3D printed case](https://github.com/selfcustody/DockEncoderCase)<br> Soldering<br>Assembly | Buttons<br> [3D printed case](https://github.com/selfcustody/MaixBitCase)<br> Soldering<br>Assembly | None | None | None |
-| Warnings  | [:material-numeric-1-circle:{ title="USB-C recognition" }](#pull-up-resistor-info) | [:material-numeric-2-circle:{ title="Maix Amigo screens" }](#amigo-info) | [:material-numeric-3-circle:{ title="Maix Dock and soldered pin" }](#dock-info) | Camera has<br> lens distortion | Micro USB | 3-Way button | [:material-numeric-1-circle:{ title="USB-C recognition" }](#pull-up-resistor-info) [:material-numeric-4-circle:{ title="WonderMV and SD card" }](#wondermv-info) |
+| Device | [M5StickV](#m5stickv) | [Maix Amigo](#maix-amigo) | [Maix Dock](#maix-dock) | [Yahboom k210 module](#yahboom-k210-module) | [Maix Cube](#maix-cube) | [WonderMV](#wondermv) |
+| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
+| Price range | US$ 50-55 | US$ 50-85 | US$ 27-35  | US$ 45-61 | US$ 34-49 | US$ 58-86 |
+| Screen size / resolution | 1.14" / 135*240 | 3.5" / 320*480 | 2.4" / 240*320 | 2" / 240*320 | 1.3" / 240*240 | 2" / 240*320 |
+| Brightness control | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: | :white_check_mark: |
+| Device size | 48\*24\*22mm | 104\*63\*17mm | 98\*59\*18mm | 57\*41\*17mm | 40\*40\*16mm | 59\*41\*17mm |
+| Touchscreen | :x: | Capacitive | :x: | Capacitive | :x: | Capacitive |
+| Camera | `OV7740` | `OV7740` rear<br>`GC0328` front | `GC0328` | `OV2640` <i style="font-size: 85%">(VER:1.0)</i> or<br>`GC2145` <i style="font-size: 85%">(VER:1.1)</i> | `OV7740` | `GC2145` |
+| Battery  | 200mAh | 520mAh | :x: | :x: | 200mAh | :x: |
+| Requirements | None | None | [Rotary encoder](https://duckduckgo.com/?q=ky-040)<br> [3D printed case](https://github.com/selfcustody/DockEncoderCase)<br> Soldering<br>Assembly | None | None | None |
+| Warnings  | [:material-numeric-1-circle:{ title="USB-C recognition" }](#pull-up-resistor-info) | [:material-numeric-2-circle:{ title="Maix Amigo screens" }](#amigo-info) | [:material-numeric-3-circle:{ title="Maix Dock and soldered pin" }](#dock-info) | Micro USB | 3-Way button | [:material-numeric-1-circle:{ title="USB-C recognition" }](#pull-up-resistor-info) [:material-numeric-4-circle:{ title="WonderMV and SD card" }](#wondermv-info) |
 
 <i style="font-size: 85%">:material-numeric-1-circle:{id="pull-up-resistor-info"}:
 ----8<----
@@ -109,15 +109,14 @@ Supported by Krux since September 2024, this touchscreen device features a metal
 
 <div style="clear: both"></div>
 
-### Maix Dock and Maix Bit
+### Maix Dock
 <img src="../img/maixpy_dock/logo-302.png" align="right" style="width: 16%;">
 
-For DIY enthusiasts, Krux has supported the Maix Dock and Maix Bit since August 2022. These kits include a board and screen but require you to source a rotary encoder or buttons separately and assemble the device yourself. Some Maix Dock boards also include Wi-Fi.
+For DIY enthusiasts, Krux has supported the Maix Dock since August 2022. These kits include a board and screen but require you to source a rotary encoder or buttons separately and assemble the device yourself. Some Maix Dock boards also include Wi-Fi.
 
 Here are example builds with instructions on how to recreate them:
 
 - [https://github.com/selfcustody/DockEncoderCase](https://github.com/selfcustody/DockEncoderCase)
-- [https://github.com/selfcustody/MaixBitCase](https://github.com/selfcustody/MaixBitCase)
 
 Available from these distributors:
 
@@ -149,4 +148,4 @@ Krux has the capability to print all QR codes it generates, including those for 
 Many TTL serial thermal printers may be compatible, but currently, the [Goojprt QR203](https://www.aliexpress.com/w/wholesale-Goojprt-QR203.html) has the best support (except this printer only supports ASCII or Chinese characters, non-ASCII characters will be printed as Chinese). The [Adafruit printer starter pack](https://www.adafruit.com/product/600) can also be a convenient option to get started, as it includes all the necessary components for printing (except the conversion cable). To ensure proper functionality, enable the printer driver in [settings](getting-started/settings.md/#thermal), set the Tx pin and baud rate value to either 19200 or 9600 (depends on the printer), as explained in this [Adafruit printer tutorial](https://learn.adafruit.com/mini-thermal-receipt-printer/first-test). You will need to connect the device's Tx to the printer's Rx and device's ground to the printer's ground, do not connect any other pins because a wrong connection may damage your device. The printer requires a dedicated power supply, typically with an output of 5 to 9V (or 12V) and capable of supplying at least 2A. For more information, [see this discussion](https://github.com/selfcustody/krux/discussions/312).
 
 #### Conversion Cable
-To connect the printer to M5StickV, Amigo or Cube, you will need a [grove conversion cable](https://store-usa.arduino.cc/products/grove-4-pin-male-to-grove-4-pin-cable-5-pcs) with a 4-pin male Grove connector on one end (to connect to the device) and 4-pin male jumpers on the other end (to connect to the printer). Check your device and printer model connection first, Yahboom comes with PH2.0 4Pin female connector; Dock and Bit doesn't have a connector; WonderMV comes with [Molex 51004 4-pin connector](https://www.digikey.ca/en/products/detail/molex/0530150410/1785079) (used with smart servo). For a more reliable connection, it is recommended to cut and solder the wires of your custom cables instead of using jumpers. Here we have a description of some [inter-integrated circuit (I2C) connector standards](https://www.cable-tester.com/i2c-pin-out/).
+To connect the printer to M5StickV, Amigo or Cube, you will need a [grove conversion cable](https://store-usa.arduino.cc/products/grove-4-pin-male-to-grove-4-pin-cable-5-pcs) with a 4-pin male Grove connector on one end (to connect to the device) and 4-pin male jumpers on the other end (to connect to the printer). Check your device and printer model connection first, Yahboom comes with PH2.0 4Pin female connector; Dock doesn't have a connector; WonderMV comes with [Molex 51004 4-pin connector](https://www.digikey.ca/en/products/detail/molex/0530150410/1785079) (used with smart servo). For a more reliable connection, it is recommended to cut and solder the wires of your custom cables instead of using jumpers. Here we have a description of some [inter-integrated circuit (I2C) connector standards](https://www.cable-tester.com/i2c-pin-out/).

--- a/docs/troubleshooting.en.md
+++ b/docs/troubleshooting.en.md
@@ -7,7 +7,7 @@ Make sure your device is being detected and serial ports are being mounted by ru
 ```bash
 ls /dev/ttyUSB*
 ```
-Expect one port to be listed for devices like M5StickV and Maix Dock `/dev/ttyUSB0`, and two ports for Maix Amigo and Maix Bit `/dev/ttyUSB0  /dev/ttyUSB1`.
+Expect one port to be listed for devices like M5StickV and Maix Dock `/dev/ttyUSB0`, and two ports for Maix Amigo `/dev/ttyUSB0  /dev/ttyUSB1`.
 
 If you don't see them, your OS may not be loading the correct drivers to create the serial ports to connect to. Ubuntu has a known bug where the `brltty` driver "kidnaps" serial devices. You can solve this problem by removing it:
 ```bash

--- a/krux
+++ b/krux
@@ -281,7 +281,7 @@ elif [ "$1" == "build-release" ]; then
     cp -f ktool-win.exe ../$release_dir/ktool-win.exe
     cd ..
 
-    devices=("maixpy_m5stickv" "maixpy_amigo" "maixpy_bit" "maixpy_dock" "maixpy_yahboom" "maixpy_cube" "maixpy_wonder_mv" "maixpy_tzt")
+    devices=("maixpy_m5stickv" "maixpy_amigo" "maixpy_dock" "maixpy_yahboom" "maixpy_cube" "maixpy_wonder_mv" "maixpy_tzt")
     for device in ${devices[@]}; do
         ./krux build $device
         mkdir -p $release_dir/$device


### PR DESCRIPTION
### What is this PR for?
Remove Maix Bit from future releases

"The Maix Bit device has long been discouraged due to its poor-quality camera. Starting with this release, we are discontinuing support and it will no longer be included in future builds. The support and parameters for building its firmware from source, however, will be kept."

### Changes made to:
- [x] Code
- [ ] Tests
- [x] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
