### PR TITLE
battery check fix

### DIFF
--- a/src/krux/kboard.py
+++ b/src/krux/kboard.py
@@ -35,7 +35,7 @@ class KBoard:
         self.is_tzt = board.config["type"] == "tzt"
         self.is_wonder_k = board.config["type"] == "wonder_k"
         self.is_m5stickv = board.config["type"] == "m5stickv"
-        self.has_battery = None  # Variable to be set in Login Page
+        self.has_battery = False  # Variable to be set in Login Page
         self.has_touchscreen = board.config["krux"]["display"].get("touch", False)
         self.has_minimal_display = self.is_m5stickv or self.is_cube
         self.can_control_brightness = any(

--- a/src/krux/kboard.py
+++ b/src/krux/kboard.py
@@ -35,7 +35,7 @@ class KBoard:
         self.is_tzt = board.config["type"] == "tzt"
         self.is_wonder_k = board.config["type"] == "wonder_k"
         self.is_m5stickv = board.config["type"] == "m5stickv"
-        self.has_battery = False  # Varible to be set by PowerManager
+        self.has_battery = None  # Variable to be set in Login Page
         self.has_touchscreen = board.config["krux"]["display"].get("touch", False)
         self.has_minimal_display = self.is_m5stickv or self.is_cube
         self.can_control_brightness = any(

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -81,7 +81,7 @@ class Login(Page):
             (t("Tools"), self.tools),
             (t("About"), self.about),
         ]
-        if kboard.has_battery is None and ctx.power_manager is not None:
+        if ctx.power_manager is not None:
             kboard.has_battery = ctx.power_manager.has_battery()
         if kboard.has_battery:
             login_menu_items.append((t("Shutdown"), self.shutdown))

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -81,8 +81,10 @@ class Login(Page):
             (t("Tools"), self.tools),
             (t("About"), self.about),
         ]
+        if kboard.has_battery is None and ctx.power_manager is not None:
+            kboard.has_battery = ctx.power_manager.has_battery()
         if kboard.has_battery:
-            login_menu_items.append((t("Shutdown"), ctx.power_manager.shutdown))
+            login_menu_items.append((t("Shutdown"), self.shutdown))
 
         super().__init__(
             ctx,

--- a/src/krux/power.py
+++ b/src/krux/power.py
@@ -42,7 +42,6 @@ class PowerManager:
             self.pmu.enable_adcs(True)
             if kboard.is_m5stickv:
                 self.pmu.enable_pek_button_monitor()
-            kboard.has_battery = self.has_battery()
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
### What is this PR for?
@jdlcdl noticed Shutdown option and battery indicator were not working on Amigo after a recent change.
Issue was kboard.has_battery flag was being cashed too early in boot, not allowing the pmu to properly detect the battery.


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on Amigo and WonderMV
### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
