### PR TITLE
Screensaver Fix

### DIFF
--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -785,7 +785,7 @@ class Menu:
                         )
                     if isinstance(selected_item_index, tuple):
                         return selected_item_index
-                elif btn is None and self.menu_offset == STATUS_BAR_HEIGHT:
+                elif btn is None and self.menu_offset <= STATUS_BAR_HEIGHT:
                     # Activates screensaver if there's no info_box(other things draw on the screen)
                     self.screensaver()
 


### PR DESCRIPTION
### What is this PR for?
Bug caught by @kdmukai. Thank you!
Screen saver is triggered only on certain menus, and Krux was using the presence of "status bar" as condition to trigger screensaver.
I introduced a bug when I removed the status bar whenever it was unused/empty, thus disabling screensaver for battery-less devices in many screens.

I see this as a temporary fix, while we don't fix another related issue: https://github.com/selfcustody/krux/issues/760

### Changes made to:
- [X] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes, build and tested on WonderMV, Amigo and TZT

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
