### PR TITLE
[Refactor] Human-friendly splash definition

### DIFF
--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -52,7 +52,6 @@ M5STICKV_WIDTH = 135
 
 ASIAN_MIN_CODEPOINT = 12288
 
-SPLASH_CHAR = "█"
 human_friendly_splash = """
   ██
   ██

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -52,20 +52,23 @@ M5STICKV_WIDTH = 135
 
 ASIAN_MIN_CODEPOINT = 12288
 
-# Splash will use horizontally-centered text plots. Uses Thin spaces to help with alignment
-SPLASH = [
-    "██" + THIN_SPACE * 3,
-    "██" + THIN_SPACE * 3,
-    "██" + THIN_SPACE * 3,
-    "██████" + THIN_SPACE * 3,
-    "██" + THIN_SPACE * 3,
-    THIN_SPACE + "██" + THIN_SPACE * 2 + "██",
-    "██" + THIN_SPACE + "██",
-    "████" + THIN_SPACE,
-    "██" + THIN_SPACE + "██",
-    THIN_SPACE + "██" + THIN_SPACE * 2 + "██",
-    THIN_SPACE * 2 + "██" + THIN_SPACE * 3 + "██",
-]
+SPLASH_CHAR = "█"
+human_friendly_splash = """
+  ██
+  ██
+  ██
+██████
+  ██
+  ██  ██
+  ██ ██
+  ████
+  ██ ██
+  ██  ██
+  ██   ██
+"""
+# Reformat as a list of strings w/fixed length padding to preserve the shape
+# when it's rendered as horizontally centered individual lines.
+SPLASH = [f"{row:9}" for row in human_friendly_splash.split("\n") if row != '']
 
 
 class Display:

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -67,7 +67,7 @@ human_friendly_splash = """
 """
 # Reformat as a list of strings w/fixed length padding to preserve the shape
 # when it's rendered as horizontally centered individual lines.
-SPLASH = [f"{row:9}" for row in human_friendly_splash.split("\n") if row != '']
+SPLASH = ["{:9}".format(row) for row in human_friendly_splash.split("\n") if row != '']
 
 
 class Display:

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -67,7 +67,7 @@ human_friendly_splash = """
 """
 # Reformat as a list of strings w/fixed length padding to preserve the shape
 # when it's rendered as horizontally centered individual lines.
-SPLASH = ["{:9}".format(row) for row in human_friendly_splash.split("\n") if row != '']
+SPLASH = ["{:<9}".format(row) for row in human_friendly_splash.split("\n") if row != '']
 
 
 class Display:


### PR DESCRIPTION
### What is this PR for?

Very minor refactor. Have a few changes coming but trying to keep each one as simple and as isolated as possible.

While working on some screensaver experiments, it seemed like the `SPLASH` definition was unnecessarily complex.

* Everything is rendered using fixed-width chars anyway so a `THIN_SPACE` shouldn't be any different than a normal space char, right?
* Makes the code look cooler. 😂
* List comprehension takes care of padding / formatting.

Question: Is the currently used version of MicroPython okay with the `f"{row:9}"` f-string formatting? 

This change is running fine in the emulator for `maixpy_amigo` but I haven't tried it on an actual device yet. I can't discern any visual difference vs the original definition.

<img width="475" height="789" alt="Screenshot 2025-11-11 at 10 26 47 AM" src="https://github.com/user-attachments/assets/c105b4df-42dd-4186-b539-b9fa3232ec3f" />


### Changes made to:
- [x] Code

### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [x] Other: light refactor