### PR TITLE
Fix Datum menu excessive y-offset

### DIFF
--- a/src/krux/pages/datum_tool.py
+++ b/src/krux/pages/datum_tool.py
@@ -628,7 +628,7 @@ class DatumTool(Page):
             if pages[-1] < endpos < content_len:
                 pages.append(endpos)
 
-            offset_y = DEFAULT_PADDING + (info_len) * FONT_HEIGHT + 1
+            offset_y = DEFAULT_PADDING + info_len * FONT_HEIGHT + 1
             for line in lines:
                 self.ctx.display.draw_string(offset_x, offset_y, line)
                 offset_y += FONT_HEIGHT
@@ -822,7 +822,7 @@ class DatumTool(Page):
         menu = Menu(
             self.ctx,
             todo_menu,
-            offset=(info_len + 1) * FONT_HEIGHT + DEFAULT_PADDING + 2,
+            offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
             **back_status
         )
         _, status = menu.run_loop()


### PR DESCRIPTION
### What is this PR for?
- Fix UI for Datum tool

Before / After

<img width="576" height="519" alt="Screenshot from 2025-11-14 22-49-58" src="https://github.com/user-attachments/assets/d735582a-f0ed-4be8-8be4-2aa2f02e7314" />

<img width="566" height="473" alt="image" src="https://github.com/user-attachments/assets/acce3e54-f6ea-4de7-8771-8e6ad75122d6" />


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on m5stickv<!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
