### PR TITLE
Docs: Update USB list port command on macOS to list more possible outputs

### DIFF
--- a/docs/getting-started/installing/from-pre-built-release.en.md
+++ b/docs/getting-started/installing/from-pre-built-release.en.md
@@ -79,7 +79,7 @@ Remove the Gatekeeper quarantine extended attribute from ktool-mac:
 xattr -d com.apple.quarantine ktool-mac
 ```
 
-See the correct port using the command line: `ls /dev/cu.usbserial*`, in the example below we use `/dev/cu.usbserial-10` (If the output isn't what you expect try a different cable, preferably a smartphone usb-c charger cable):
+See the correct port using the command line: `ls /dev/cu.usb*`, in the example below we use `/dev/cu.usbserial-10` (If the output isn't what you expect try a different cable, preferably a smartphone usb-c charger cable):
 ```bash
 ./ktool-mac -B goE -b 1500000 maixpy_amigo/kboot.kfpkg -p /dev/cu.usbserial-10
 ```


### PR DESCRIPTION
Update USB list port command on macOS to list more possible outputs.

https://t.me/SC_Krux/27627

On my tzt device on macOS the device was listed as `/dev/cu.usbmodem58FC0675851` instead of a `/dev/cu.usbserial*`

In some cases `/dev/cu.usbmodem*` devices are listed instead of just `/dev/cu.usbserial*`

### What is this PR for?

Documentation update

### Changes made to:
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Other
