### PR TITLE
Reduce UR QR code density using uppercase alphanumeric encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ From the wonderful land of Korea, a new creation arrives: the WonderK PRO. Creat
 ### Changed BIP39 Passphrase Validation
 Krux now displays a warning instead of blocking QR-encoded passphrases that contain non-ASCII characters. Users are encouraged to use QR codes containing only ASCII passphrases or non-ASCII that have already been normalized to NFKD.
 
+### Easier to Scan UR QR Codes
+Exported Uniform Resource (UR) QR codes, a widely adopted standard for exchanging PSBTs, now use uppercase data to reduce QR density, improving scan reliability without increasing the number of frames.
+
 ### Other Bug Fixes and Improvements
 - Added backtick ` to keypad
 - Bugfix: Screensaver not activating in menu pages without statusbar

--- a/src/krux/qr.py
+++ b/src/krux/qr.py
@@ -261,7 +261,7 @@ def to_qr_codes(data, max_width, qr_format):
 
             encoder = UREncoder(data, part_size, 0)
             while True:
-                part = encoder.next_part()
+                part = encoder.next_part().upper()
                 code = qrcode.encode(part)
                 yield (code, encoder.fountain_encoder.seq_len())
         elif qr_format == FORMAT_BBQR:


### PR DESCRIPTION
### What is this PR for?
Switches to uppercase letters for UR QR codes, which allows more efficient encoding without increasing frame count.
This improves scanning reliability when transferring PSBTs back to the coordinator, especially on devices with small, high-DPI displays like Yahboom, WonderMV, and TZT.

### Changes made to:
- [X] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes, build and tested on Amigo (and Sparrow, Nunchuck and BULL coordinators)

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
