### PR TITLE
Refactor capture entropy test to be less fragile, more DRY

### DIFF
--- a/tests/pages/test_capture_entropy.py
+++ b/tests/pages/test_capture_entropy.py
@@ -5,13 +5,16 @@ import random
 
 def _called_with_insufficient_entropy_message(ctx):
     """Helper bool to determine if ctx.display.draw_centered_text was called with a message including "Insufficient" """
-    return len(
-        [
-            call
-            for call in ctx.display.draw_centered_text.call_args_list
-            if "Insufficient" in call.args[0]
-        ]
-    ) > 0
+    return (
+        len(
+            [
+                call
+                for call in ctx.display.draw_centered_text.call_args_list
+                if "Insufficient" in call.args[0]
+            ]
+        )
+        > 0
+    )
 
 
 def test_cancel_capture(amigo, mocker):


### PR DESCRIPTION
### What is this PR for?

Refactor to make the `test_capture_entropy.py` tests less fragile. Original tests were reconstructing the exact `draw_centered_text` args to test against, creating an unnecessary maintenance burden. This revised approach simply looks for the presence of "Insufficient" in any of its calls.

Revision ends up being more DRY and simplifies the tests a bit.

Minor fixes to two comments that were incorrectly saying the test was for "Insufficient" when it was actually the success case.

Minor fixes to remove redundant `CameraEntropy` instantiation.

---

### Changes made to:
- [x] Tests

### Did you build the code and tested on device?
- [x] N/A

### What is the purpose of this pull request?
- [x] Other: test improvement
