### PR TITLE
[bugfix] Wrong index number displayed after editing a 24-word mnemonic on m5stickv

### DIFF
--- a/src/krux/pages/mnemonic_editor.py
+++ b/src/krux/pages/mnemonic_editor.py
@@ -326,7 +326,7 @@ class MnemonicEditor(Page):
                 if new_word is not None:
                     self.ctx.display.clear()
                     if self.prompt(
-                        str(button_index + 1) + ".\n\n" + new_word + "\n\n",
+                        str(button_index + page * 12 + 1) + ".\n\n" + new_word + "\n\n",
                         self.ctx.display.height() // 2,
                     ):
                         self.current_mnemonic[button_index + page * 12] = new_word


### PR DESCRIPTION
### What is this PR for?

Bugfix. Only occurs on small displays that require paged `MnemonicEditor` display.

Steps to reproduce on m5stickv:
* Create a new 24-word mnemonic.
* Page forward to view the 2nd half of the mnemonic.
* Click a word to edit it.
* The displayed index number here will be correct. Let's say 18.
* Click to continue to the keyboard entry UI.
* Change the word.
* The confirmation display will show the new word but with the wrong index number. It'll be `index_number - 12 + 1`. So 6 in this example. 

---

### Changes made to:
- [x] Code

### Did you build the code and tested on device?
- [x] Yes, build and tested on: m5stickv, tzt, wonder_k

### What is the purpose of this pull request?
- [x] Bug fix