### PR TITLE
Scan QR codes inverted (black bg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Exported Uniform Resource (UR) QR codes, a widely adopted standard for exchangin
 - Bugfix: Screensaver not activating in menu pages without statusbar
 - Embit: Improved BIP39 mnemonic validation
 - Bug Fix: Corrected handling of certain binary-encoded QR codes
+- QR codes: Added support for inverted QR codes, enabling scans of QRs with a black background
 
 # Changelog 25.10.1 - October 2025
 

--- a/src/krux/pages/qr_capture.py
+++ b/src/krux/pages/qr_capture.py
@@ -131,11 +131,16 @@ class QRCodeCapture(Page):
         self.ctx.display.draw_centered_text(t("Loading Camera…"))
         self.ctx.camera.initialize_run()
 
+        read_none = 0
+        read_normal = 1
+        read_inverted = 2
+
         parser = QRPartParser()
         prev_parsed_count = 0
         new_part = None
         previous_part = None
         ur_highlighted = False
+        read_qr_success = read_none
 
         # Flush events ocurred while loading camera
         self.ctx.input.reset_ios_state()
@@ -189,7 +194,18 @@ class QRCodeCapture(Page):
             else:
                 self.ctx.display.render_image(img)
 
-            res = img.find_qrcodes()
+            if read_qr_success != read_inverted:
+                res = img.find_qrcodes()
+                if res:
+                    read_qr_success = read_normal
+
+            # try inverted colors if not sucessfull
+            if read_qr_success != read_normal:
+                img.invert()
+                res = img.find_qrcodes()
+                if res:
+                    read_qr_success = read_inverted
+
             if res:
                 data = res[0].payload()
                 new_part = parser.parse(data)


### PR DESCRIPTION
### What is this PR for?
Added support for inverted QR codes, enabling scans of QRs with a black background


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on TZT<!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other
