### PR TITLE
Fix Krux script wrong baudrate for dock

### DIFF
--- a/krux
+++ b/krux
@@ -108,11 +108,13 @@ elif [ "$1" == "flash" -o "$1" == "boot" -o "$1" == "boot-terminal" -o "$1" == "
         BAUDRATE=2000000
         if [ "$device" == "maixpy_embed_fire" ]; then
             BAUDRATE=400000
+        elif [ "$device" == "maixpy_m5stickv" ]||
+        [ "$device" == "maixpy_dock" ]; then
+            BAUDRATE=1500000
         fi
         if [ "$device" == "maixpy_m5stickv" ]; then
             # https://devicehunt.com/view/type/usb/vendor/0403/device/6001
             device_vendor_product_id="0403:6001"
-            BAUDRATE=1500000
         elif [ "$device" == "maixpy_amigo" ]||
         [ "$device" == "maixpy_bit" ]||
         [ "$device" == "maixpy_cube" ]; then


### PR DESCRIPTION
### What is this PR for?
Higher baud rates caused the Dock to fail intermittently during the flash process, so I switched to a lower rate. It’s a bit slower, but consistently successful.


### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on dock, m5stickv <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
