### PR TITLE
Ignore edge touches and bad swipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Exported Uniform Resource (UR) QR codes, a widely adopted standard for exchangin
 ### Other Bug Fixes and Improvements
 - Settings: Reduced default _Buttons Debounce_ value (with an even lower default on _M5StickV_)
 - Settings: Expanded value ranges for _Touch Threshold_ and _Buttons Debounce_
-- Swipe handling: Detection threshold has been slightly reduced
+- Swipe handling: Diagonal and long-hold swipes are now discarded, and the swipe detection threshold has been slightly reduced
+- Touch handling: Discards touches near edges of adjacent regions
 - Keypad: Added backtick **`**
 - Bugfix: Screensaver not activating in menu pages without statusbar
 - Embit: Improved BIP39 mnemonic validation

--- a/src/krux/input.py
+++ b/src/krux/input.py
@@ -19,6 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+# pylint: disable=unnecessary-lambda
+
 import time
 import board
 from .wdt import wdt
@@ -35,6 +37,7 @@ SWIPE_RIGHT = 4
 SWIPE_LEFT = 5
 SWIPE_UP = 6
 SWIPE_DOWN = 7
+SWIPE_FAIL = 99
 FAST_FORWARD = 8
 FAST_BACKWARD = 9
 
@@ -175,29 +178,30 @@ class Input:
             return self.touch.event(validate_position)
         return False
 
+    def _swipe_check_value(self, swipe_fnc):
+        if kboard.has_touchscreen:
+            return swipe_fnc()
+        return RELEASED
+
+    def swipe_none_value(self):
+        """Intermediary method to pull touch gesture, if touch available"""
+        return self._swipe_check_value(lambda: self.touch.swipe_none_value())
+
     def swipe_right_value(self):
         """Intermediary method to pull touch gesture, if touch available"""
-        if kboard.has_touchscreen:
-            return self.touch.swipe_right_value()
-        return RELEASED
+        return self._swipe_check_value(lambda: self.touch.swipe_right_value())
 
     def swipe_left_value(self):
         """Intermediary method to pull touch gesture, if touch available"""
-        if kboard.has_touchscreen:
-            return self.touch.swipe_left_value()
-        return RELEASED
+        return self._swipe_check_value(lambda: self.touch.swipe_left_value())
 
     def swipe_up_value(self):
         """Intermediary method to pull touch gesture, if touch available"""
-        if kboard.has_touchscreen:
-            return self.touch.swipe_up_value()
-        return RELEASED
+        return self._swipe_check_value(lambda: self.touch.swipe_up_value())
 
     def swipe_down_value(self):
         """Intermediary method to pull touch gesture, if touch available"""
-        if kboard.has_touchscreen:
-            return self.touch.swipe_down_value()
-        return RELEASED
+        return self._swipe_check_value(lambda: self.touch.swipe_down_value())
 
     def wdt_feed_inc_entropy(self):
         """Feeds the watchdog and increments the input's entropy"""
@@ -310,6 +314,10 @@ class Input:
             while self.touch_value() == PRESSED:
                 self.wdt_feed_inc_entropy()
             self.buttons_active = False
+
+            # Check if was a swipe
+            if self.swipe_none_value() == PRESSED:
+                return SWIPE_FAIL
             if self.swipe_right_value() == PRESSED:
                 return SWIPE_RIGHT
             if self.swipe_left_value() == PRESSED:
@@ -318,6 +326,8 @@ class Input:
                 return SWIPE_UP
             if self.swipe_down_value() == PRESSED:
                 return SWIPE_DOWN
+
+            # was a simple touch
             return BUTTON_TOUCH
 
         if btn in [BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV]:

--- a/src/krux/pages/keypads.py
+++ b/src/krux/pages/keypads.py
@@ -28,6 +28,7 @@ from ..input import (
     BUTTON_ENTER,
     BUTTON_PAGE,
     BUTTON_PAGE_PREV,
+    BUTTON_TOUCH,
     SWIPE_RIGHT,
     SWIPE_LEFT,
     SWIPE_UP,
@@ -256,11 +257,19 @@ class Keypad:
     def touch_to_physical(self):
         """Convert a touch press in button press"""
         self.cur_key_index = self.ctx.input.touch.current_index()
-        actual_button = None
+        if self.cur_key_index < 0:
+            self.cur_key_index = 0
+            return BUTTON_TOUCH
+
+        special_keys = [self.del_index, self.esc_index, self.go_index]
+        if self.has_more_key():
+            special_keys.append(self.more_index)
+
+        actual_button = BUTTON_TOUCH
         if self.cur_key_index < len(self.keys):
             if self.keys[self.cur_key_index] in self.possible_keys:
                 actual_button = BUTTON_ENTER
-        elif self.cur_key_index < self.layout.max_index:
+        elif self.cur_key_index in special_keys:
             actual_button = BUTTON_ENTER
         else:
             self.cur_key_index = 0

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -41,7 +41,13 @@ from ..krux_settings import (
     t,
     locale_control,
 )
-from ..input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV, BUTTON_TOUCH
+from ..input import (
+    BUTTON_ENTER,
+    BUTTON_PAGE,
+    BUTTON_PAGE_PREV,
+    BUTTON_TOUCH,
+    SWIPE_FAIL,
+)
 from ..sd_card import SDHandler
 from . import (
     Page,
@@ -83,32 +89,33 @@ class SettingsPage(Page):
 
     def _draw_settings_pad(self):
         """Draws buttons to change settings with touch"""
-        if kboard.has_touchscreen:
-            self.ctx.input.touch.clear_regions()
-            offset_y = self.ctx.display.height() * 2 // 3
-            self.ctx.input.touch.add_y_delimiter(offset_y)
-            self.ctx.input.touch.add_y_delimiter(offset_y + FONT_HEIGHT * 3)
-            button_width = (self.ctx.display.width() - 2 * DEFAULT_PADDING) // 3
-            for i in range(4):
-                self.ctx.input.touch.add_x_delimiter(DEFAULT_PADDING + button_width * i)
-            offset_y += FONT_HEIGHT
-            keys = ["<", t("Go"), ">"]
-            for i, x in enumerate(self.ctx.input.touch.x_regions[:-1]):
-                self.ctx.display.outline(
-                    x,
-                    self.ctx.input.touch.y_regions[0],
-                    button_width - 1,
-                    FONT_HEIGHT * 3,
-                    theme.frame_color,
-                )
-                offset_x = x
-                offset_x += (button_width - lcd.string_width_px(keys[i])) // 2
-                self.ctx.display.draw_string(
-                    offset_x, offset_y, keys[i], theme.fg_color, theme.bg_color
-                )
+        self.ctx.input.touch.clear_regions()
+        offset_y = self.ctx.display.height() * 2 // 3
+        self.ctx.input.touch.add_y_delimiter(offset_y)
+        self.ctx.input.touch.add_y_delimiter(offset_y + FONT_HEIGHT * 3)
+        button_width = (self.ctx.display.width() - 2 * DEFAULT_PADDING) // 3
+        for i in range(4):
+            self.ctx.input.touch.add_x_delimiter(DEFAULT_PADDING + button_width * i)
+        offset_y += FONT_HEIGHT
+        keys = ["<", t("Go"), ">"]
+        for i, x in enumerate(self.ctx.input.touch.x_regions[:-1]):
+            self.ctx.display.outline(
+                x,
+                self.ctx.input.touch.y_regions[0],
+                button_width - 1,
+                FONT_HEIGHT * 3,
+                theme.frame_color,
+            )
+            offset_x = x
+            offset_x += (button_width - lcd.string_width_px(keys[i])) // 2
+            self.ctx.display.draw_string(
+                offset_x, offset_y, keys[i], theme.fg_color, theme.bg_color
+            )
 
     def _touch_to_physical(self, index):
         """Mimics touch presses into physical button presses"""
+        if index < 0:
+            return BUTTON_TOUCH
         if index == 0:
             return BUTTON_PAGE_PREV
         if index == 1:
@@ -373,10 +380,15 @@ class SettingsPage(Page):
                 color,
                 theme.bg_color,
             )
-            self._draw_settings_pad()
-            btn = self.ctx.input.wait_for_button()
-            if btn == BUTTON_TOUCH:
-                btn = self._touch_to_physical(self.ctx.input.touch.current_index())
+            if kboard.has_touchscreen:
+                self._draw_settings_pad()
+
+            # wait until valid input is captured
+            btn = BUTTON_TOUCH
+            while btn in (BUTTON_TOUCH, SWIPE_FAIL):
+                btn = self.ctx.input.wait_for_button()
+                if btn == BUTTON_TOUCH:
+                    btn = self._touch_to_physical(self.ctx.input.touch.current_index())
             if btn == BUTTON_ENTER:
                 break
 

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -714,6 +714,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     from krux.baseconv import base_encode
     from krux.pages.encryption_ui import decrypt_kef, KEFEnvelope
     from krux.input import BUTTON_PAGE_PREV
+    from krux.themes import theme
 
     # setup data: a fake kef envelope, non-kef data, decrypt-evidence, and responding "No" to "Decrypt?"
     fake_kef = kef.wrap(b"", 0, 10000, bytes([i * 8 for i in range(32)]))
@@ -728,7 +729,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test w/ non-kef bytes")
     ctx = create_ctx(mocker, [])
@@ -737,7 +740,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test w/ kef hex")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -746,7 +749,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test with non-kef hex")
     ctx = create_ctx(mocker, [])
@@ -755,7 +760,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with invalid hex-ish str")
     ctx = create_ctx(mocker, [])
@@ -764,7 +769,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with kef HEX")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -773,7 +778,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test with non-kef HEX")
     ctx = create_ctx(mocker, [])
@@ -782,7 +789,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with invalid HEX-ish str")
     ctx = create_ctx(mocker, [])
@@ -791,7 +798,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with kef base32")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -800,7 +807,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test with non-kef base32")
     ctx = create_ctx(mocker, [])
@@ -809,7 +818,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with invalid base32-ish str")
     ctx = create_ctx(mocker, [])
@@ -818,7 +827,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with kef base43")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -827,7 +836,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test with non-kef base43")
     ctx = create_ctx(mocker, [])
@@ -836,7 +847,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with invalid base43-ish str")
     ctx = create_ctx(mocker, [])
@@ -845,7 +856,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with kef base64")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -854,7 +865,9 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
-    ctx.display.to_lines.assert_called_with(evidence)
+    ctx.display.draw_hcentered_text.assert_called_with(
+        evidence, 120, theme.fg_color, theme.bg_color, highlight_prefix=""
+    )
 
     print("test with non-kef base64")
     ctx = create_ctx(mocker, [])
@@ -863,7 +876,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
     print("test with invalid base64-ish str")
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -872,7 +885,7 @@ def test_decrypt_kef_offers_decrypt_ui_appropriately(m5stickv, mocker):
     except ValueError:
         pass
     assert ctx.input.wait_for_button.call_count == 0
-    ctx.display.to_lines.assert_not_called()
+    ctx.display.draw_hcentered_text.assert_not_called()
 
 
 def test_prompt_for_text_update_dflt_via_yes(m5stickv, mocker):

--- a/tests/pages/test_keypads.py
+++ b/tests/pages/test_keypads.py
@@ -19,3 +19,13 @@ def test_button_turbo(mocker, m5stickv):
     ctx.input.page_prev_value = mocker.MagicMock(side_effect=[PRESSED, None])
     keypad.navigate(FAST_BACKWARD)
     keypad._previous_key.assert_called()
+
+
+def test_invalid_touch_index(mocker, amigo):
+    from krux.pages.keypads import Keypad
+    from krux.input import BUTTON_TOUCH
+
+    ctx = create_ctx(mocker, [BUTTON_TOUCH], touch_seq=[-1])
+    keypad = Keypad(ctx, "abc")
+    btn = keypad.touch_to_physical()
+    assert keypad.cur_key_index == 0

--- a/tests/pages/test_menu.py
+++ b/tests/pages/test_menu.py
@@ -122,6 +122,16 @@ def test_run_loop_on_amigo_tft(mocker, amigo):
     assert status == MENU_SHUTDOWN
     assert ctx.input.wait_for_fastnav_button.call_count == call_count
 
+    # Check invalid touch index don't change result
+    BTN_SEQUENCE.insert(1, BUTTON_TOUCH)
+    call_count += len(BTN_SEQUENCE)
+    # invalid touch index
+    mocker.patch.object(ctx.input.touch, "current_index", new=lambda: -1)
+    ctx.input.wait_for_fastnav_button.side_effect = BTN_SEQUENCE
+    index, status = menu.run_loop()
+    assert status == MENU_SHUTDOWN
+    assert ctx.input.wait_for_fastnav_button.call_count == call_count
+
     mocker.patch.object(ctx.input.touch, "current_index", new=lambda: 1)
     mocker.patch.object(ctx.input, "buttons_active", False)
 

--- a/tests/pages/test_mnemonic_editor.py
+++ b/tests/pages/test_mnemonic_editor.py
@@ -269,6 +269,7 @@ def test_edit_existing_mnemonic_using_touch(mocker, amigo):
         1,
         1,
         1,  # Confirm cabbage
+        -1,  # Try a swipe return invalid index
         25,  # Try to "Go" with invalid checksum word
         23,  # index 23 = word 24
         22,  # Type w, i, t -> witness

--- a/tests/pages/test_settings_page.py
+++ b/tests/pages/test_settings_page.py
@@ -266,6 +266,7 @@ def test_settings_on_amigo_tft(amigo, mocker, mocker_printer):
     PREV_INDEX = 0
     GO_INDEX = 1
     NEXT_INDEX = 2
+    INVALID_INDEX = -1  # SWIPE
 
     HARDWARE_INDEX = 2
     LOCALE_INDEX = 3
@@ -331,6 +332,9 @@ def test_settings_on_amigo_tft(amigo, mocker, mocker_printer):
                 LOCALE_INDEX,
                 # Change Locale
                 NEXT_INDEX,
+                NEXT_INDEX,
+                INVALID_INDEX,
+                PREV_INDEX,
                 GO_INDEX,
             ),
             [

--- a/tests/pages/test_stackbit.py
+++ b/tests/pages/test_stackbit.py
@@ -122,8 +122,10 @@ def test_enter_stackbit_touch(amigo, mocker):
     from krux.input import BUTTON_TOUCH
 
     YES = 1
-    BTN_SEQUENCE = [BUTTON_TOUCH] * 3 * 12 + [BUTTON_TOUCH]
-    TOUCH_SEQUENCE = [0, STACKBIT_GO_INDEX + 1, YES] * 12 + [YES]
+    BTN_SEQUENCE = [BUTTON_TOUCH] * 4 * 12 + [BUTTON_TOUCH]
+    TOUCH_SEQUENCE = [0, -1, STACKBIT_GO_INDEX + 1, YES] * 12 + [
+        YES
+    ]  # negative values (invalid touches) should not change the result
     TEST_12_WORDS = "language language language language language language language language language language language language"
 
     ctx = create_ctx(mocker, BTN_SEQUENCE, touch_seq=TOUCH_SEQUENCE)
@@ -181,3 +183,15 @@ def test_entering_stackbit_buttons_turbo(mocker, m5stickv):
         stackbit.enter_1248()
 
     stackbit.index.assert_called_with(0, FAST_BACKWARD)
+
+
+def test_stackbit_index_ignore_swipe(mocker, amigo):
+    from krux.pages.stack_1248 import Stackbit
+    from krux.input import SWIPE_LEFT, SWIPE_RIGHT, SWIPE_DOWN, SWIPE_UP, SWIPE_FAIL
+
+    ctx = create_ctx(mocker, [])
+    stackbit = Stackbit(ctx)
+    tmp = 10
+    for swipe in (SWIPE_LEFT, SWIPE_RIGHT, SWIPE_DOWN, SWIPE_UP, SWIPE_FAIL):
+        new_index = stackbit.index(tmp, swipe)
+        assert new_index == tmp

--- a/tests/pages/test_tiny_seed.py
+++ b/tests/pages/test_tiny_seed.py
@@ -176,6 +176,8 @@ def test_enter_tiny_seed_24w_amigo(amigo, mocker):
         + [3]
         # Toggle to last editable bit
         + [135]
+        # An invalid index don't change result
+        + [-1]
         # Press ESC
         + [TS_ESC_START_POSITION]
         # Give up from ESC

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -373,6 +373,14 @@ def test_swipe_down_value_released_when_none(mocker, m5stickv):
     assert input.swipe_down_value() == RELEASED
 
 
+def test_swipe_fail_value_released_when_none(mocker, m5stickv):
+    from krux.input import Input, RELEASED
+
+    input = Input()
+    input.touch = None
+    assert input.swipe_none_value() == RELEASED
+
+
 def test_wait_for_release(mocker, m5stickv):
     import krux
     from krux.input import Input, RELEASED, PRESSED, BUTTON_ENTER
@@ -676,7 +684,14 @@ def test_touch_indexing(mocker, amigo):
 
 def test_touch_gestures(mocker, amigo):
     import krux
-    from krux.input import Input, SWIPE_LEFT, SWIPE_RIGHT, SWIPE_UP, SWIPE_DOWN
+    from krux.input import (
+        Input,
+        SWIPE_LEFT,
+        SWIPE_RIGHT,
+        SWIPE_UP,
+        SWIPE_DOWN,
+        SWIPE_FAIL,
+    )
 
     input = Input()
     input = reset_input_states(mocker, input)
@@ -691,6 +706,7 @@ def test_touch_gestures(mocker, amigo):
             "current_point",
             side_effect=[None, point1, point2, None, None],
         )
+        input.touch.pressed_time = time.ticks_ms()
 
     # Swipe Right
     input.touch.clear_regions()
@@ -718,6 +734,13 @@ def test_touch_gestures(mocker, amigo):
     mock_points((75, 50), (75, 150))
     btn = input.wait_for_button(True)
     assert btn == SWIPE_DOWN
+    krux.input.wdt.feed.assert_called()
+
+    # Swipe Fail
+    input.touch.clear_regions()
+    mock_points((75, 50), (150, 100))
+    btn = input.wait_for_button(True)
+    assert btn == SWIPE_FAIL
     krux.input.wdt.feed.assert_called()
 
 


### PR DESCRIPTION
### What is this PR for?

#### Touch / Swipe handling
- **Diagonal swipes**: Swipes are now accepted only if the delta on one axis is 2 times greater than the other
- **Long-hold**: Long hold swipes (>750ms) are now ignored
- **Edge touches**: Discards touches near edges of adjacent regions

#### Other
- Refactored Page **Prompt** to reuse logic from its `draw_proceed_menu`
- Added title highlighting support for **Tinyseed** and **Stackbit**

Second PR from https://github.com/selfcustody/krux/pull/771

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on Embed Fire<!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
