### PR TITLE
Datum Loading UR crypto-bip39

### DIFF
--- a/src/krux/pages/datum_tool.py
+++ b/src/krux/pages/datum_tool.py
@@ -82,6 +82,7 @@ def urobj_to_data(ur_obj):
 
     if ur_obj.type == "crypto-bip39":
         data = urtypes.crypto.BIP39.from_cbor(ur_obj.cbor).words
+        data = " ".join(data)
     elif ur_obj.type == "crypto-account":
         data = (
             urtypes.crypto.Account.from_cbor(ur_obj.cbor)

--- a/tests/pages/test_datum_tool.py
+++ b/tests/pages/test_datum_tool.py
@@ -36,10 +36,7 @@ def test_urobj_to_data(m5stickv, mocker):
     MULTISIG_DESCR = "wsh(multi(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/0/0/*))#t2zpj2eu"
 
     cases = [
-        {
-            "control": UR("crypto-bip39", UR_BIP39_WORDS_BYTES),
-            "expected": MNEMONIC.split(" "),
-        },
+        {"control": UR("crypto-bip39", UR_BIP39_WORDS_BYTES), "expected": MNEMONIC},
         {
             "control": UR("crypto-output", UR_OUTPUT_MULTISIG_DESCR_BYTES),
             "expected": MULTISIG_DESCR,


### PR DESCRIPTION
### What is this PR for?
Join list returned by `urtypes.crypto.BIP39.from_cbor(ur_obj.cbor).words` so Datum can load and display it.


### Changes made to:
- [X] Code
- [X] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes, build and tested on TZT

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
