### PR TITLE
Fix: adjust fingerprint warning message for rare case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Exported Uniform Resource (UR) QR codes, a widely adopted standard for exchangin
 - Bugfix: Screensaver not activating in menu pages without statusbar
 - Embit: Improved BIP39 mnemonic validation
 - Bug Fix: Corrected handling of certain binary-encoded QR codes
+- Fix fingerprint unset warn message for rare case
 - Improved QR code decoding performance and added inverted color QR code detection
 
 # Changelog 25.10.1 - October 2025

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -400,7 +400,10 @@ class Home(Page):
                 return False
 
         # Fix zero fingerprint, it is necessary for the signing process on embit in a few cases
-        if signer.fill_zero_fingerprint():
+        if (
+            self.ctx.wallet.key.fingerprint != b"\x00\x00\x00\x00"
+            and signer.fill_zero_fingerprint()
+        ):
             self.ctx.display.clear()
             self.ctx.display.draw_centered_text(t("Fingerprint unset in PSBT"))
             if not self.prompt(t("Proceed?"), BOTTOM_PROMPT_LINE):


### PR DESCRIPTION
### What is this PR for?

@kdmukai demonstrated that a valid 12-word mnemonic can legitimately produce a `00000000` fingerprint. Krux was incorrectly showing the warning **"Fingerprint unset in PSBT"** in this case.


Below there is a Compact Seed QR and a testnet PSBT to aid in reviewing.

Compact Seed QR:
`caught siege debate lab loan digital front absurd stone pull evolve rebuild`

<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/ffaff8b4-1b9e-434e-832f-20a7de2af698" />

PSBT file:
[zero.psbt.txt](https://github.com/user-attachments/files/23966065/zero.psbt.txt)

PSBT QR:
<img width="455" height="452" alt="image" src="https://github.com/user-attachments/assets/ce2a4131-9926-4614-8c6f-e56df16ddebf" />

----------------
Another:
`fold sleep kit flip elder fringe boat pulse gallery parrot mask weird mechanic away true huge cigar dirt almost hello put trap strike match`

<img width="327" height="337" alt="image" src="https://github.com/user-attachments/assets/c717b3bd-7a38-446f-91af-f314f6273750" />


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on Embed Fire <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
