### PR TITLE
UI: Improve exit prompts with contextual information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Exported Uniform Resource (UR) QR codes, a widely adopted standard for exchangin
 - Keypad: Added backtick **`**
 - Bugfix: Screensaver not activating in menu pages without statusbar
 - Embit: Improved BIP39 mnemonic validation
-- Bug Fix: Corrected handling of certain binary-encoded QR codes
+- Bugfix: Corrected handling of certain binary-encoded QR codes
+- UI: Added contextual information to "Are you sure?" exit prompts
 - Fix fingerprint unset warn message for rare case
 - Improved QR code decoding performance and added inverted color QR code detection
 

--- a/src/krux/pages/__init__.py
+++ b/src/krux/pages/__init__.py
@@ -103,7 +103,10 @@ class Page:
     def esc_prompt(self):
         """Prompts user for leaving"""
         self.ctx.display.clear()
-        answer = self.prompt(t("Are you sure?"), self.ctx.display.height() // 2)
+        answer = self.prompt(
+            t("Back to Menu") + "\n\n" + t("Are you sure?"),
+            self.ctx.display.height() >> 1,
+        )
         if kboard.has_touchscreen:
             self.ctx.input.touch.clear_regions()
         return ESC_KEY if answer else None
@@ -522,7 +525,11 @@ class Page:
 
     def shutdown(self):
         """Handler for the 'shutdown' menu item"""
-        if self.prompt(t("Are you sure?"), self.ctx.display.height() // 2):
+        shtn_reboot_label = t("Shutdown") if kboard.has_battery else t("Reboot")
+        if self.prompt(
+            shtn_reboot_label + "\n\n" + t("Are you sure?"),
+            self.ctx.display.height() >> 1,
+        ):
             self.ctx.display.clear()
             self.ctx.display.draw_centered_text(t("Shutting down…"))
             time.sleep_ms(SHUTDOWN_WAIT_TIME)

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -319,7 +319,10 @@ class Login(MnemonicLoader):
 
             index, _ = submenu.run_loop()
             if index == submenu.back_index:
-                if self.prompt(t("Are you sure?"), self.ctx.display.height() // 2):
+                if self.prompt(
+                    t("Back to Menu") + "\n\n" + t("Are you sure?"),
+                    self.ctx.display.height() >> 1,
+                ):
                     del key
                     return MENU_CONTINUE
             if index == 0:

--- a/src/krux/pages/mnemonic_editor.py
+++ b/src/krux/pages/mnemonic_editor.py
@@ -316,7 +316,10 @@ class MnemonicEditor(Page):
                 if button_index == ESC_INDEX:
                     # Cancel
                     self.ctx.display.clear()
-                    if self.prompt(t("Are you sure?"), self.ctx.display.height() // 2):
+                    if self.prompt(
+                        t("Back to Menu") + "\n\n" + t("Are you sure?"),
+                        self.ctx.display.height() >> 1,
+                    ):
                         return None
                     continue
                 new_word = self.edit_word(button_index + page * 12)

--- a/src/krux/pages/stack_1248.py
+++ b/src/krux/pages/stack_1248.py
@@ -459,7 +459,10 @@ class Stackbit(Page):
                         word_index += 1
                 elif index >= STACKBIT_ESC_INDEX:  # ESC
                     self.ctx.display.clear()
-                    if self.prompt(t("Are you sure?"), self.ctx.display.height() // 2):
+                    if self.prompt(
+                        t("Back to Menu") + "\n\n" + t("Are you sure?"),
+                        self.ctx.display.height() >> 1,
+                    ):
                         break
                     # self._map_keys_array()
                 elif index < 14:

--- a/src/krux/pages/tiny_seed.py
+++ b/src/krux/pages/tiny_seed.py
@@ -388,7 +388,10 @@ class TinySeed(Page):
                     page += 1
                 elif index >= TS_ESC_START_POSITION:  # "Esc"
                     self.ctx.display.clear()
-                    if self.prompt(t("Are you sure?"), self.ctx.display.height() // 2):
+                    if self.prompt(
+                        t("Back to Menu") + "\n\n" + t("Are you sure?"),
+                        self.ctx.display.height() >> 1,
+                    ):
                         break
                     self._map_keys_array()
                 elif _editable_bit():


### PR DESCRIPTION
### What is this PR for?
As @kdmukai pointed out on Krux chat, when doing things fast, as in workshops for example, "Are you sure?" prompts doesn't help much. This PR adds a little context to those prompts that exit actions.


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on embed_fire<!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
