### PR TITLE
fix: printer does not update TX/RX pin

### DIFF
--- a/src/krux/printers/cnc.py
+++ b/src/krux/printers/cnc.py
@@ -373,12 +373,12 @@ class GRBLPrinter(GCodeGenerator):
         fm.register(
             Settings().hardware.printer.cnc.grbl.tx_pin,
             fm.fpioa.UART2_TX,
-            force=False,
+            force=True,
         )
         fm.register(
             Settings().hardware.printer.cnc.grbl.rx_pin,
             fm.fpioa.UART2_RX,
-            force=False,
+            force=True,
         )
 
         self.uart_conn = UART(UART.UART2, Settings().hardware.printer.cnc.grbl.baudrate)

--- a/src/krux/printers/thermal.py
+++ b/src/krux/printers/thermal.py
@@ -56,12 +56,12 @@ class AdafruitPrinter(Printer):
         fm.register(
             Settings().hardware.printer.thermal.adafruit.tx_pin,
             fm.fpioa.UART2_TX,
-            force=False,
+            force=True,
         )
         fm.register(
             Settings().hardware.printer.thermal.adafruit.rx_pin,
             fm.fpioa.UART2_RX,
-            force=False,
+            force=True,
         )
 
         self.uart_conn = UART(


### PR DESCRIPTION
### What is this PR for?

Fixes an issue where the printer TX/RX pin is not updated correctly after changing the configuration.

### Steps to reproduce

1. On **M5StickV**, go to `Settings > Hardware > Printer > Driver` and set it to `thermal/adafruit`.
   Then go to `Thermal > TX Pin`, set it to `39`, go back, and save the settings.
2. Go to `Tools > Device Tests > Print Test QR` and confirm **“Print as QR?”**.
   (Nothing happens, as the pin is invalid.)
3. Return to `Settings > Hardware > Printer > Thermal > TX Pin`, set it to `35`, go back, and save the settings.
4. Go again to `Tools > Device Tests > Print Test QR` and confirm **“Print as QR?”**.
   (An error occurs.)

### Error

```
Error: Exception: [Warning] function is used by unknown (pin:39)
```

### Result

After this PR, the error no longer occurs and the printer works correctly when following the same steps.



### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on M5StickV<!-- device-name -->

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
