### PR TITLE
ci: add qlrd/pymarkdownlnt-gh-action to lint-docs workflow job 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
 
 jobs:
+
   lint-black:
     runs-on: ubuntu-latest
     steps:
@@ -108,3 +109,14 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  lint-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qlrd/pymarkdownlnt-gh-action@v1
+        with:
+          disable-rules: "MD013,MD025,MD033,MD036,MD041"
+          enable-rules:  "MD024"
+          paths:         "./**.md"
+          warn-only:     "true"


### PR DESCRIPTION
### What is this PR for?

`pymarkdownlnt` is a nice lib that lints markdown documents. It check for good formatting and standards managed by [CommonMark](https://spec.commonmark.org/). As proof of concept, the linter was applied only to the README.md.


### Changes made to:
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Other
