### PR TITLE
fix: build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,16 @@ RUN apt-get update -y && \
         python3-setuptools
 
 RUN mkdir -p /opt && \
-    git clone --depth 1 --recurse-submodules --shallow-submodules --branch v8.2.0-20190409 https://github.com/kendryte/kendryte-gnu-toolchain
+    GIT_TERMINAL_PROMPT=0 \
+    git clone --depth 1 --branch v8.2.0-20190409 https://github.com/kendryte/kendryte-gnu-toolchain
+
+RUN cd kendryte-gnu-toolchain && \
+    sed -i 's|https://github.com/bminor/binutils-gdb.git|https://github.com/riscvarchive/riscv-binutils-gdb.git|' .gitmodules && \
+    git submodule sync && \
+    git submodule update \
+      --init \
+      --recursive \
+      --depth 1
 
 RUN cd kendryte-gnu-toolchain && \
     export PATH=$PATH:/opt/kendryte-toolchain/bin && \


### PR DESCRIPTION
### What is this PR for?
Fix docker build process after repo from github changed from https://github.com/bminor/binutils-gdb to https://github.com/riscvarchive/riscv-binutils-gdb


### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
