### PR TITLE
Remove duplicated HEX and OCT digit constants

### DIFF
--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -50,9 +50,6 @@ from ..key import (
 from ..krux_settings import t
 from ..kboard import kboard
 
-DIGITS_HEX = "0123456789ABCDEF"
-DIGITS_OCT = "01234567"
-
 DOUBLE_MNEMONICS_MAX_TRIES = 200
 MASK256 = (1 << 256) - 1
 MASK128 = (1 << 128) - 1


### PR DESCRIPTION
### What is this PR for?

Remove duplicated HEX and OCT digit constants (were moved to `src/krux/pages/mnemonic_loader.py`)


### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
