### PR TITLE
fix: reject PSBT inputs with non-standard sighash types before signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changelog 26.03.1 - March 2025
+
+### Security Fixes
+Reject PSBT inputs with non-standard sighash types before signing
+
 # Changelog 26.03.0 - March 2025
 
 ### New Device Support: Embed Fire

--- a/src/krux/psbt.py
+++ b/src/krux/psbt.py
@@ -431,8 +431,26 @@ class PSBTSigner:
 
         return messages, fee_percent
 
+    def check_sighash(self):
+        """Check that all inputs use SIGHASH_ALL (or DEFAULT for taproot).
+
+        Refuse to sign if any input requests a non-standard sighash type
+        (SIGHASH_NONE, SIGHASH_SINGLE, ANYONECANPAY), as these can allow
+        an attacker to redirect funds after signing.
+        """
+        from embit.transaction import SIGHASH
+
+        safe_sighash = {None, SIGHASH.DEFAULT, SIGHASH.ALL}
+        for i, inp in enumerate(self.psbt.inputs):
+            if inp.sighash_type not in safe_sighash:
+                sighash_val = inp.sighash_type
+                raise ValueError(
+                    "Input %d has non-standard sighash type: 0x%02x" % (i, sighash_val)
+                )
+
     def add_signatures(self):
         """Add signatures to PSBT"""
+        self.check_sighash()
         sigs_added = self.psbt.sign_with(self.wallet.key.root)
         if sigs_added == 0:
             raise ValueError("cannot sign")

--- a/tests/test_psbt.py
+++ b/tests/test_psbt.py
@@ -1522,6 +1522,98 @@ def test_sign_fails_with_0_sigs_added(mocker, m5stickv, tdata):
     signer.psbt.sign_with.assert_called_with(wallet.key.root)
 
 
+def test_check_sighash_rejects_sighash_none(mocker, m5stickv, tdata):
+    from embit.networks import NETWORKS
+    from embit.transaction import SIGHASH
+    from krux.psbt import PSBTSigner
+    from krux.key import Key, TYPE_SINGLESIG
+    from krux.wallet import Wallet
+    from krux.qr import FORMAT_NONE
+
+    wallet = Wallet(Key(tdata.TEST_MNEMONIC, TYPE_SINGLESIG, NETWORKS["test"]))
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    # Inject SIGHASH_NONE into the first input
+    signer.psbt.inputs[0].sighash_type = SIGHASH.NONE
+
+    with pytest.raises(ValueError, match="non-standard sighash type: 0x02"):
+        signer.sign()
+
+
+def test_check_sighash_rejects_sighash_single(mocker, m5stickv, tdata):
+    from embit.networks import NETWORKS
+    from embit.transaction import SIGHASH
+    from krux.psbt import PSBTSigner
+    from krux.key import Key, TYPE_SINGLESIG
+    from krux.wallet import Wallet
+    from krux.qr import FORMAT_NONE
+
+    wallet = Wallet(Key(tdata.TEST_MNEMONIC, TYPE_SINGLESIG, NETWORKS["test"]))
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    signer.psbt.inputs[0].sighash_type = SIGHASH.SINGLE
+
+    with pytest.raises(ValueError, match="non-standard sighash type: 0x03"):
+        signer.sign()
+
+
+def test_check_sighash_rejects_anyonecanpay(mocker, m5stickv, tdata):
+    from embit.networks import NETWORKS
+    from embit.transaction import SIGHASH
+    from krux.psbt import PSBTSigner
+    from krux.key import Key, TYPE_SINGLESIG
+    from krux.wallet import Wallet
+    from krux.qr import FORMAT_NONE
+
+    wallet = Wallet(Key(tdata.TEST_MNEMONIC, TYPE_SINGLESIG, NETWORKS["test"]))
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    signer.psbt.inputs[0].sighash_type = SIGHASH.ALL | SIGHASH.ANYONECANPAY
+
+    with pytest.raises(ValueError, match="non-standard sighash type: 0x81"):
+        signer.sign()
+
+
+def test_check_sighash_allows_default_and_all(mocker, m5stickv, tdata):
+    from embit.networks import NETWORKS
+    from embit.transaction import SIGHASH
+    from krux.psbt import PSBTSigner
+    from krux.key import Key, TYPE_SINGLESIG
+    from krux.wallet import Wallet
+    from krux.qr import FORMAT_NONE
+
+    wallet = Wallet(Key(tdata.TEST_MNEMONIC, TYPE_SINGLESIG, NETWORKS["test"]))
+
+    # SIGHASH_ALL should be accepted (signs successfully)
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    signer.psbt.inputs[0].sighash_type = SIGHASH.ALL
+    signer.sign()  # Should not raise
+
+    # SIGHASH_DEFAULT should be accepted
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    signer.psbt.inputs[0].sighash_type = SIGHASH.DEFAULT
+    signer.sign()  # Should not raise
+
+    # None (unset) should be accepted
+    signer = PSBTSigner(wallet, tdata.P2WPKH_PSBT, FORMAT_NONE)
+    signer.psbt.inputs[0].sighash_type = None
+    signer.sign()  # Should not raise
+
+
+def test_check_sighash_reports_correct_input_index(mocker, m5stickv, tdata):
+    from embit.networks import NETWORKS
+    from embit.transaction import SIGHASH
+    from krux.psbt import PSBTSigner
+    from krux.key import Key, TYPE_SINGLESIG
+    from krux.wallet import Wallet
+    from krux.qr import FORMAT_NONE
+
+    wallet = Wallet(Key(tdata.TEST_MNEMONIC, TYPE_SINGLESIG, NETWORKS["test"]))
+    signer = PSBTSigner(wallet, tdata.P2PKH_PSBT, FORMAT_NONE)
+    # P2PKH_PSBT has 3 inputs; set non-standard sighash on the third one
+    if len(signer.psbt.inputs) >= 3:
+        signer.psbt.inputs[2].sighash_type = SIGHASH.NONE
+        with pytest.raises(ValueError, match="Input 2"):
+            signer.sign()
+
+
 def test_outputs_singlesig(mocker, m5stickv, tdata):
     from embit.networks import NETWORKS
     from krux.psbt import PSBTSigner


### PR DESCRIPTION
### What is this PR for?

Although Embit already refuses to sign inputs with non-ALL sighash by default, this adds a redundant pre-sign validation that refuses to sign if any input requests SIGHASH_NONE, SIGHASH_SINGLE, or ANYONECANPAY, which could allow an attacker to redirect funds after signing. Addresses security audit C2 of #843


### Changes made to:
- [X] Code
- [X] Tests
- [ ] Docs
- [X] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes, build and tested on Amigo + Sparrow

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
