### PR TITLE
chore: add a cyclomatic complexity plugin to `pylint`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ black.ref = "format"
 format-test.ref = "format-tests"
 
 # pylint tasks
-lint-src = "pylint src"
+lint-src = "pylint --load-plugins=pylint.extensions.mccabe --max-complexity=20  src"
 lint-scripts = "pylint firmware/font/*.py firmware/scripts/*.py i18n/*.py"
 lint = ["lint-src", "lint-scripts"]
 # aliases


### PR DESCRIPTION
### What is this PR for?

This PR add a feature commented by @jaonoctus on a [\#847 comment](https://github.com/selfcustody/krux/pull/847/changes#r3029819808), where an review about multiple lines review could be avoided automatically if we apply the `mccabe` plugin to `pylint`.

E.g, visually complexity could lead humans to interpret some lines as complex given a experience of how code should be or not to be; some standars could say that 25 lines could be the limit of a readability. But a cyclomatic complexity on a function could be used as a "how real complex is the function" and "it should be really refactored?".

Tested with `max-complexity=13` and `max-complexity=20` in tags `v26.03.0`, branches `main`, `develop` and
`feat/stackbit-1248-vertical`. For more details about values a wikipedia short ref:

* `>=1 && < 10`: Simple procedure: `little risk`;
* `>=11 && <20`: More complex: `moderate risk`;
* `>=21 && <50`: Complex: `high risk`.
* `> 50`: Untestable code: `very high risk`;

Tests show some codes that aren't above 20, but could be lead to a better reading for future devs and some functions on 22 and 39:

```
************* Module krux.encryption
...
src/krux/firmware.py:282:0: R1260: 'upgrade' is too complex. The McCabe rating is 22 (too-complex)
...
src/krux/input.py:259:4: R1260: '_detect_press_type' is too complex. The McCabe rating is 25 (too-complex)
...
src/krux/psbt.py:55:4: R1260: '__init__' is too complex. The McCabe rating is 22 (too-complex)
...
src/krux/pages/datum_tool.py:168:0: R1260: 'detect_encodings' is too complex. The McCabe rating is 39 (too-complex)
src/krux/pages/datum_tool.py:421:4: R1260: 'view_qr' is too complex. The McCabe rating is 21 (too-complex)
...
src/krux/pages/encryption_ui.py:52:0: R1260: 'decrypt_kef' is too complex. The McCabe rating is 23 (too-complex)
src/krux/pages/encr
...
src/krux/pages/qr_view.py:503:4: R1260: 'display_qr' is too complex. The McCabe rating is 21 (too-complex)
...
------------------------------------------------------------------
Your code has been rated at 9.94/10 (previous run: 9.94/10, +0.00)
```

I think the project could gain with this check and i think i some way is a crafting to me fix those stuffs. Even if fail loccally, it must pass on CI because the plugin use pylint differently.

- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [ ] Yes, build and tested on 

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
