### PR TITLE
fix: validate settings.json on load to prevent OOM and type confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog 26.03.1 - March 2025
+# Changelog 26.04.0 - April 2025
 
 ### Security Fixes
 - Reject PSBT inputs with non-standard sighash types before signing
@@ -7,6 +7,7 @@
 - Validate multisig quorum: reject m=0 and m>n in key-value wallet files
 - DeflateIO enforces 100KB max decompressed size, preventing zip bomb OOM via BBQR encoding "Z" or KEF decryption
 - Enforce part_total limits in pMofN (1–99) and BBQR (≥1) QR parsers, preventing OOM via unbounded part accumulation
+- Validate settings.json on load: enforce max file size and reject non-object payloads, preventing OOM and type-confusion via a malicious SD card
 
 # Changelog 26.03.0 - March 2025
 

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -35,6 +35,10 @@ FLASH_PATH = "flash"
 SETTINGS_FILENAME = "settings.json"
 MNEMONICS_FILE = "seeds.json"
 
+# Maximum accepted size of settings.json (bytes). Guards against malicious
+# oversized files on SD that could exhaust RAM during load.
+MAX_SETTINGS_FILE_SIZE = 8192
+
 # Network settings
 MAIN_TXT = "main"
 TEST_TXT = "test"
@@ -191,10 +195,22 @@ class Store:
         return "/" + location + "/"
 
     def _load_settings(self):
-        """Loads settings based on the current file_location (SD/flash)"""
+        """Loads settings based on the current file_location (SD/flash).
+
+        Rejects files larger than MAX_SETTINGS_FILE_SIZE and any payload whose
+        top-level value is not a JSON object. Per-setting type/range/category
+        validation is enforced lazily by the Setting descriptors on read.
+        """
         try:
             with open(self.file_location + SETTINGS_FILENAME, "r") as f:
-                self.settings = json.loads(f.read())
+                # Read one extra byte to detect oversized files
+                contents = f.read(MAX_SETTINGS_FILE_SIZE + 1)
+            if len(contents) > MAX_SETTINGS_FILE_SIZE:
+                return
+            loaded = json.loads(contents)
+            if not isinstance(loaded, dict):
+                return
+            self.settings = loaded
         except:
             pass
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -117,6 +117,48 @@ def test_string_stored_adafruit_printer_settings(mocker, m5stickv):
     assert ada.line_delay == 20
 
 
+def test_oversized_settings_file_is_rejected(mocker, m5stickv):
+    """A settings.json larger than MAX_SETTINGS_FILE_SIZE must be discarded."""
+    from krux.settings import MAX_SETTINGS_FILE_SIZE
+
+    # Build a syntactically valid JSON object whose serialized form exceeds the cap
+    padding = "A" * (MAX_SETTINGS_FILE_SIZE + 100)
+    stored_settings = (
+        '{"settings": {"i18n": {"locale": "pt-BR"}}, "junk": "%s"}' % padding
+    )
+    assert len(stored_settings) > MAX_SETTINGS_FILE_SIZE
+
+    mocker.patch("builtins.open", mocker.mock_open(read_data=stored_settings))
+
+    from krux.settings import Store
+
+    store = Store()
+    # Oversized payload must be ignored: nothing loaded
+    assert store.settings == {}
+
+
+def test_non_dict_settings_file_is_rejected(mocker, m5stickv):
+    """A settings.json whose top-level JSON value isn't an object must be discarded."""
+    stored_settings = '["settings", "i18n", "pt-BR"]'
+    mocker.patch("builtins.open", mocker.mock_open(read_data=stored_settings))
+
+    from krux.settings import Store
+
+    store = Store()
+    assert store.settings == {}
+
+
+def test_malformed_settings_file_is_rejected(mocker, m5stickv):
+    """Invalid JSON must not crash the loader and must leave settings empty."""
+    stored_settings = "{not valid json"
+    mocker.patch("builtins.open", mocker.mock_open(read_data=stored_settings))
+
+    from krux.settings import Store
+
+    store = Store()
+    assert store.settings == {}
+
+
 def test_stored_cnc_settings(mocker, m5stickv):
     print("")
 


### PR DESCRIPTION
### What is this PR for?
Enforces a maximum file size and rejects non-object payloads when loading settings.json from SD/flash.


### Changes made to:
- [X] Code
- [X] Tests
- [ ] Docs
- [X] CHANGELOG


### Did you build the code and tested on device?
- [X] Yes, build and tested on Amigo

### What is the purpose of this pull request?
- [X] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
