### PR TITLE
chore(git): ignore AI-assisted configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,11 @@ krux-*/ktool*
 
 # IDE files
 .vscode
-.claude
+
+# AI tooling local context (per maintainer policy, never commit)
+.agents/
+.codex/
+.claude/
+.cursorrules
+AGENT.md
+CLAUDE.md


### PR DESCRIPTION
### What is this PR for?

Add some common AI configuration files, such as `CLAUDE.md`, `AGENT.md`, `.cursorrules` and
`.claude/` (and not `.claude`) since it should be a per-maintainer policy on local
development machine.


### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG
- [x] git

### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: addition to `.gitignore` entries
