### PR TITLE
Silent Payment Address & Descriptor Support.

### DIFF
--- a/src/krux/key.py
+++ b/src/krux/key.py
@@ -22,6 +22,7 @@
 # pylint: disable=W0102
 import time
 
+from collections import namedtuple
 import urandom as random
 from binascii import hexlify
 from hashlib import sha256
@@ -72,12 +73,14 @@ P2TR = "p2tr"
 NAME_SINGLE_SIG = "Single-sig"
 NAME_MULTISIG = "Multisig"
 NAME_MINISCRIPT = "Miniscript"
+NAME_SILENT_PAYMENT = "Single-sig SP"
 
 # Policy types names
 POLICY_TYPE_NAMES = [
     NAME_SINGLE_SIG,
     NAME_MULTISIG,
     NAME_MINISCRIPT,
+    NAME_SILENT_PAYMENT,
 ]
 
 SINGLESIG_SCRIPT_NAMES = [
@@ -90,6 +93,10 @@ SINGLESIG_SCRIPT_NAMES = [
 MULTISIG_SCRIPT_NAMES = ["Legacy - 45", "Nested Segwit - 48", "Native Segwit - 48"]
 
 MINISCRIPT_SCRIPT_NAMES = ["Native Segwit - 48", "Taproot - 48"]
+
+SILENT_PAYMENT_SCRIPT_NAMES = ["Taproot - 352"]
+
+DER_SILENT_PAYMENT = "m/352h/%dh/%dh"
 
 
 # Single-sig script types supported by Krux
@@ -124,11 +131,13 @@ MINISCRIPT_PURPOSE = 48
 TYPE_SINGLESIG = 0
 TYPE_MULTISIG = 1
 TYPE_MINISCRIPT = 2
+TYPE_SILENT_PAYMENT = 3
 
 POLICY_TYPE_IDS = {
     NAME_SINGLE_SIG: TYPE_SINGLESIG,
     NAME_MULTISIG: TYPE_MULTISIG,
     NAME_MINISCRIPT: TYPE_MINISCRIPT,
+    NAME_SILENT_PAYMENT: TYPE_SILENT_PAYMENT,
 }
 
 # Reverse mapping: policy type ID to name
@@ -136,11 +145,17 @@ POLICY_TYPE_NAMES_MAP = {
     TYPE_SINGLESIG: NAME_SINGLE_SIG,
     TYPE_MULTISIG: NAME_MULTISIG,
     TYPE_MINISCRIPT: NAME_MINISCRIPT,
+    TYPE_SILENT_PAYMENT: NAME_SILENT_PAYMENT,
 }
 
 
 FINGERPRINT_SYMBOL = "⊚"
 DERIVATION_PATH_SYMBOL = "↳"
+
+# Groups the BIP-352 silent payment keys derived for a Key
+SilentPaymentKeys = namedtuple(
+    "SilentPaymentKeys", ["scan_privkey", "spend_privkey", "spend_pubkey"]
+)
 
 
 class Key:
@@ -174,6 +189,10 @@ class Key:
         if policy_type == TYPE_MINISCRIPT and script_type not in (P2WSH, P2TR):
             script_type = P2WSH
 
+        # SP always uses P2TR
+        if policy_type == TYPE_SILENT_PAYMENT:
+            script_type = P2TR
+
         self.script_type = script_type
         self.root = Key.extract_root(mnemonic, passphrase, network)
         self.fingerprint = self.root.child(0).fingerprint
@@ -184,6 +203,15 @@ class Key:
         else:
             self.derivation = derivation
         self.account = self.root.derive(self.derivation).to_public()
+
+        if policy_type == TYPE_SILENT_PAYMENT:
+            scan_privkey = self.root.derive(self.derivation + "/1h/0").key
+            spend_privkey = self.root.derive(self.derivation + "/0h/0").key
+            self.sp_keys = SilentPaymentKeys(
+                scan_privkey, spend_privkey, spend_privkey.get_public_key()
+            )
+        else:
+            self.sp_keys = None
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -263,6 +291,32 @@ class Key:
         )
         return ser
 
+    def sp_scan_key(self, network_name):
+        """Returns the BIP-352 SPScanKey object with origin metadata"""
+        from embit.descriptor.sp import SPScanKey
+        from embit.descriptor.arguments import KeyOrigin
+        from embit.bip32 import parse_path
+
+        origin = KeyOrigin(self.fingerprint, parse_path(self.derivation))
+        return SPScanKey(
+            self.sp_keys.scan_privkey,
+            self.sp_keys.spend_pubkey,
+            origin=origin,
+            network=network_name,
+        )
+
+    def sp_scan_key_encoded(self, network_name):
+        """Returns the BIP-352 scan key as a key expression with fingerprint/derivation prefix"""
+        return str(self.sp_scan_key(network_name))
+
+    def sp_address(self, network_name):
+        """Returns the BIP-352 silent payment address"""
+        from embit.silent_payments.bip352 import generate_silent_payment_address
+
+        return generate_silent_payment_address(
+            self.sp_keys.scan_privkey, self.sp_keys.spend_pubkey, network=network_name
+        )
+
     @staticmethod
     def pick_final_word(entropy, words):
         """Returns a random final word with a valid checksum for the given list of
@@ -310,6 +364,11 @@ class Key:
         if policy_type == TYPE_MINISCRIPT:
             return DER_MINISCRIPT % (
                 MINISCRIPT_PURPOSE,
+                network["bip32"],
+                0 if account is None else account,
+            )
+        if policy_type == TYPE_SILENT_PAYMENT:
+            return DER_SILENT_PAYMENT % (
                 network["bip32"],
                 0 if account is None else account,
             )

--- a/src/krux/krux_settings.py
+++ b/src/krux/krux_settings.py
@@ -36,10 +36,12 @@ from .key import (
     NAME_SINGLE_SIG,
     NAME_MULTISIG,
     NAME_MINISCRIPT,
+    NAME_SILENT_PAYMENT,
     POLICY_TYPE_NAMES,
     SINGLESIG_SCRIPT_NAMES,
     MULTISIG_SCRIPT_NAMES,
     MINISCRIPT_SCRIPT_NAMES,
+    SILENT_PAYMENT_SCRIPT_NAMES,
 )
 
 from .kboard import kboard
@@ -162,6 +164,11 @@ class DefaultWallet(SettingsNamespace):
         lambda input, l_set: (
             (MINISCRIPT_SCRIPT_NAMES, MINISCRIPT_SCRIPT_NAMES[0])
             if input == NAME_MINISCRIPT
+            else (l_set.categories, l_set.default_value)
+        ),
+        lambda input, l_set: (
+            (SILENT_PAYMENT_SCRIPT_NAMES, SILENT_PAYMENT_SCRIPT_NAMES[0])
+            if input == NAME_SILENT_PAYMENT
             else (l_set.categories, l_set.default_value)
         ),
     )

--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -50,6 +50,11 @@ class Addresses(Page):
             self.flash_error(t("Please load a wallet output descriptor"))
             return MENU_CONTINUE
 
+        if self.ctx.wallet.is_silent_payment():
+            addr = self.ctx.wallet.obtain_sp_address()
+            self.show_address(addr, title=format_address(addr))
+            return MENU_CONTINUE
+
         submenu = Menu(
             self.ctx,
             [

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -33,7 +33,7 @@ from ...display import BOTTOM_PROMPT_LINE
 from ...qr import FORMAT_NONE, FORMAT_PMOFN
 from ...krux_settings import t, Settings
 from ...format import replace_decimal_separator
-from ...key import TYPE_SINGLESIG
+from ...key import TYPE_SINGLESIG, TYPE_SILENT_PAYMENT
 from ...kboard import kboard
 
 
@@ -350,9 +350,9 @@ class Home(Page):
 
     def _pre_load_psbt_warn(self):
         """Warns if descriptor is not loaded and wallet is multisig or miniscript"""
-        if (
-            not self.ctx.wallet.is_loaded()
-            and self.ctx.wallet.key.policy_type != TYPE_SINGLESIG
+        if not self.ctx.wallet.is_loaded() and self.ctx.wallet.key.policy_type not in (
+            TYPE_SINGLESIG,
+            TYPE_SILENT_PAYMENT,
         ):
             self.ctx.display.draw_centered_text(
                 t("Warning:")
@@ -389,9 +389,9 @@ class Home(Page):
 
         # Show the policy for multisig and miniscript PSBTs
         # in case the wallet descriptor is not loaded
-        if (
-            not self.ctx.wallet.is_loaded()
-            and not self.ctx.wallet.key.policy_type == TYPE_SINGLESIG
+        if not self.ctx.wallet.is_loaded() and self.ctx.wallet.key.policy_type not in (
+            TYPE_SINGLESIG,
+            TYPE_SILENT_PAYMENT,
         ):
             policy_str = signer.psbt_policy_string()
             self.ctx.display.clear()

--- a/src/krux/pages/home_pages/pub_key_view.py
+++ b/src/krux/pages/home_pages/pub_key_view.py
@@ -38,8 +38,78 @@ WALLET_XPUB_START = 4
 class PubkeyView(Page):
     """UI to show and export extended public key"""
 
+    def _sp_scan_key_view(self):
+        """Handler for showing the BIP-352 scan key for SP wallets"""
+        net_name = self.ctx.wallet.which_network()
+        spscan = self.ctx.wallet.key.sp_scan_key_encoded(net_name)
+        descriptor_str = str(self.ctx.wallet.descriptor)
+
+        def _show_text():
+            from ...themes import theme
+            from ..file_operations import SaveFile
+
+            items = [
+                (
+                    t("Save to SD card"),
+                    (
+                        None
+                        if not self.has_sd_card()
+                        else lambda: SaveFile(self.ctx).save_file(
+                            spscan,
+                            "SPSCAN",
+                            "SPSCAN",
+                            "SPSCAN:",
+                            ".txt",
+                            save_as_binary=False,
+                        )
+                    ),
+                ),
+            ]
+            spscan_key_only = (
+                spscan[spscan.index("]") + 1 :] if "]" in spscan else spscan
+            )
+            info_text = (
+                "\n\n"
+                + self.ctx.wallet.key.derivation_str(pretty=True)
+                + "\n\n"
+                + spscan_key_only
+            )
+            offset = (len(self.ctx.display.to_lines(info_text)) + 1) * FONT_HEIGHT
+            menu = Menu(self.ctx, items, offset=offset)
+            self.ctx.display.clear()
+            self.ctx.display.draw_hcentered_text(
+                info_text, offset_y=FONT_HEIGHT, info_box=True
+            )
+            self.ctx.display.draw_hcentered_text(
+                self.ctx.wallet.key.fingerprint_hex_str(pretty=True),
+                offset_y=FONT_HEIGHT,
+                color=theme.highlight_color,
+                bg_color=theme.info_bg_color,
+            )
+            menu.run_loop()
+
+        def _show_qr():
+            from ..qr_view import SeedQRView
+
+            SeedQRView(self.ctx, data=descriptor_str, title="SPSCAN").display_qr(
+                allow_export=True, transcript_tools=False
+            )
+
+        items = [
+            ("SPSCAN - " + t("Text"), _show_text),
+            ("SPSCAN - " + t("QR Code"), _show_qr),
+        ]
+        menu = Menu(self.ctx, items)
+        while True:
+            _, status = menu.run_loop()
+            if status == MENU_EXIT:
+                break
+        return MENU_CONTINUE
+
     def public_key(self):
         """Handler for the 'xpub' menu item"""
+        if self.ctx.wallet.is_silent_payment():
+            return self._sp_scan_key_view()
 
         def _save_xpub_to_sd(version):
             from ..file_operations import SaveFile

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -38,12 +38,14 @@ from ..key import (
     P2WPKH,
     P2WSH,
     P2SH,
+    P2TR,
     SINGLESIG_SCRIPT_MAP,
     MULTISIG_SCRIPT_MAP,
     MINISCRIPT_SCRIPT_MAP,
     TYPE_SINGLESIG,
     TYPE_MULTISIG,
     TYPE_MINISCRIPT,
+    TYPE_SILENT_PAYMENT,
     POLICY_TYPE_IDS,
     NAME_MULTISIG,
 )
@@ -252,6 +254,9 @@ class Login(MnemonicLoader):
             script_type = MINISCRIPT_SCRIPT_MAP.get(
                 Settings().wallet.script_type, P2WSH
             )
+
+        if policy_type == TYPE_SILENT_PAYMENT:
+            script_type = P2TR
 
         derivation_path = ""
 

--- a/src/krux/pages/utils.py
+++ b/src/krux/pages/utils.py
@@ -161,8 +161,14 @@ class Utils(Page):
             TYPE_SINGLESIG,
             TYPE_MULTISIG,
             TYPE_MINISCRIPT,
+            TYPE_SILENT_PAYMENT,
         )
-        from ..key import NAME_SINGLE_SIG, NAME_MULTISIG, NAME_MINISCRIPT
+        from ..key import (
+            NAME_SINGLE_SIG,
+            NAME_MULTISIG,
+            NAME_MINISCRIPT,
+            NAME_SILENT_PAYMENT,
+        )
 
         wallet_info = network + "\n"
 
@@ -174,6 +180,8 @@ class Utils(Page):
             if is_login and script == P2TR:
                 wallet_info += "TR "
             wallet_info += NAME_MINISCRIPT
+        elif policy == TYPE_SILENT_PAYMENT:
+            wallet_info += NAME_SILENT_PAYMENT
 
         wallet_info += "\n"
 

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -39,12 +39,15 @@ from ..key import (
     SINGLESIG_SCRIPT_PURPOSE,
     MULTISIG_SCRIPT_PURPOSE,
     MINISCRIPT_PURPOSE,
+    DER_SILENT_PAYMENT,
     TYPE_SINGLESIG,
     TYPE_MULTISIG,
     TYPE_MINISCRIPT,
+    TYPE_SILENT_PAYMENT,
     NAME_SINGLE_SIG,
     NAME_MULTISIG,
     NAME_MINISCRIPT,
+    NAME_SILENT_PAYMENT,
 )
 
 from ..settings import (
@@ -223,7 +226,10 @@ class WalletSettings(Page):
                 [
                     (t("Network"), lambda: None),
                     (t("Policy Type"), lambda: None),
-                    (t("Script Type"), lambda: None),
+                    (
+                        t("Script Type"),
+                        None if policy_type == TYPE_SILENT_PAYMENT else lambda: None,
+                    ),
                     (account_txt, lambda: None),
                 ],
                 offset=info_len * FONT_HEIGHT + DEFAULT_PADDING,
@@ -272,6 +278,9 @@ class WalletSettings(Page):
                         # If is miniscript, pick P2WSH or P2TR
                         script_type = self._miniscript_type()
                         script_type = P2WSH if script_type is None else script_type
+
+                    elif policy_type == TYPE_SILENT_PAYMENT:
+                        script_type = P2TR
 
             elif index == 2:
                 if policy_type == TYPE_MINISCRIPT:
@@ -322,6 +331,7 @@ class WalletSettings(Page):
                 (NAME_SINGLE_SIG, lambda: MENU_EXIT),
                 (NAME_MULTISIG, lambda: MENU_EXIT),
                 (NAME_MINISCRIPT + " (Experimental)", lambda: MENU_EXIT),
+                (NAME_SILENT_PAYMENT + " (Experimental)", lambda: MENU_EXIT),
             ],
             disable_statusbar=True,
         )
@@ -386,6 +396,10 @@ class WalletSettings(Page):
         # to maintain compatibility with those wallets, use m/45h.
         if policy_type == TYPE_MULTISIG and script_type == P2SH:
             return P2SH_DEFAULT_DERIVATION
+
+        if policy_type == TYPE_SILENT_PAYMENT:
+            coin = 0 if network == NETWORKS[MAIN_TXT] else 1
+            return DER_SILENT_PAYMENT % (coin, account)
 
         derivation_path = "m/"
 

--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -21,6 +21,7 @@
 
 from embit.descriptor.descriptor import Descriptor
 from embit.descriptor.arguments import Key
+from embit.descriptor.sp import SilentPaymentDescriptor
 from embit.networks import NETWORKS
 from .krux_settings import t
 from .qr import FORMAT_BBQR, FORMAT_NONE
@@ -35,6 +36,8 @@ from .key import (
     TYPE_SINGLESIG,
     TYPE_MULTISIG,
     TYPE_MINISCRIPT,
+    TYPE_SILENT_PAYMENT,
+    NAME_SILENT_PAYMENT,
 )
 
 
@@ -54,6 +57,7 @@ class Wallet:
         self.policy = None
         self.persisted = False
         self._network = None
+        self._sp_address = None
         if self.key and self.key.policy_type == TYPE_SINGLESIG:
             if self.key.script_type == P2PKH:
                 self.descriptor = Descriptor.from_string(
@@ -74,6 +78,14 @@ class Wallet:
                 )
             self.label = t("Single-sig")
             self.policy = {"type": self.get_scriptpubkey_type()}
+        elif self.key and self.key.policy_type == TYPE_SILENT_PAYMENT:
+            net_name = self.which_network()
+            self.descriptor = SilentPaymentDescriptor(
+                sp_key=self.key.sp_scan_key(net_name)
+            )
+            self.label = t(NAME_SILENT_PAYMENT)
+            self.policy = {"type": P2TR}
+            self._sp_address = self.key.sp_address(net_name)
 
     def get_scriptpubkey_type(self):
         """Returns the scriptpubkey type of the wallet descriptor"""
@@ -126,12 +138,25 @@ class Wallet:
             )
         return False
 
+    def is_silent_payment(self):
+        """Returns a boolean indicating whether or not the wallet is silent payment"""
+        if self.key:
+            return self.key.policy_type == TYPE_SILENT_PAYMENT
+        return False
+
+    def obtain_sp_address(self):
+        """Returns the cached silent payment address"""
+        return self._sp_address
+
     def is_loaded(self):
         """Returns a boolean indicating whether or not this wallet has been loaded"""
         return self.wallet_data is not None
 
     def _determine_descriptor_policy(self, descriptor):
         """Returns required policy type and script type from descriptor"""
+        if isinstance(descriptor, SilentPaymentDescriptor):
+            return TYPE_SILENT_PAYMENT, P2TR
+
         descriptor_is_multisig = descriptor.is_basic_multisig
         descriptor_is_miniscript = not descriptor_is_multisig and (
             descriptor.miniscript is not None or descriptor.taptree
@@ -171,6 +196,8 @@ class Wallet:
 
     def _validate_xpub_match(self, descriptor, descriptor_xpubs):
         """Validates that key's xpub matches the descriptor"""
+        if self.is_silent_payment():
+            return  # SP wallets use scan key, not xpub
         if self.is_multisig():
             if not descriptor.is_basic_multisig:
                 raise ValueError("not multisig")
@@ -223,6 +250,8 @@ class Wallet:
 
     def load(self, wallet_data, qr_format):
         """Loads the wallet from the given data"""
+        if self.is_silent_payment():
+            raise ValueError("SP wallets do not load external descriptors")
         descriptor, label = parse_wallet(wallet_data)
 
         # convert descriptor keys to 'xpub' on same network -- for comparison only
@@ -308,6 +337,11 @@ class Wallet:
         """Returns an iterator deriving addresses (default branch_index is receive)
         for the wallet up to the provided limit"""
 
+        if self.is_silent_payment():
+            if i == 0:
+                yield self._sp_address
+            return
+
         if self.descriptor is None:
             raise ValueError("No descriptor to derive addresses from")
 
@@ -321,7 +355,8 @@ class Wallet:
 
     def has_change_addr(self):
         """Returns if this wallet knows how to derive its change addresses"""
-
+        if self.is_silent_payment():
+            return False
         return self.descriptor.num_branches > 1
 
 

--- a/tests/pages/home_pages/test_addresses.py
+++ b/tests/pages/home_pages/test_addresses.py
@@ -1179,3 +1179,20 @@ def test_list_change_addresses(mocker, m5stickv, tdata):
 
         # assert the number of calls to wait_for_button
         assert ctx.input.wait_for_button.call_count == len(sequence_buttons)
+
+
+def test_silent_payment_address(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.addresses import Addresses
+    from krux.pages import MENU_CONTINUE
+    from krux.wallet import Wallet
+
+    wallet = Wallet(tdata.SILENT_PAYMENT_KEY)
+    ctx = create_ctx(mocker, None, wallet, None)
+    addresses_ui = Addresses(ctx)
+    mock_show_address = mocker.patch.object(addresses_ui, "show_address")
+
+    assert addresses_ui.addresses_menu() == MENU_CONTINUE
+
+    # SP wallets show the single cached silent payment address
+    mock_show_address.assert_called_once()
+    assert mock_show_address.call_args.args[0] == wallet.obtain_sp_address()

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -20,6 +20,7 @@ def tdata(mocker):
         TYPE_MINISCRIPT,
         TYPE_MULTISIG,
         TYPE_SINGLESIG,
+        TYPE_SILENT_PAYMENT,
         Key,
         P2WPKH,
     )
@@ -121,6 +122,10 @@ def tdata(mocker):
         TEST_12_WORD_MNEMONIC, TYPE_MINISCRIPT, NETWORKS["main"], script_type=P2TR
     )
 
+    SILENT_PAYMENT_KEY = Key(
+        TEST_12_WORD_MNEMONIC, TYPE_SILENT_PAYMENT, NETWORKS["test"]
+    )
+
     VAGUE_LEGACY1_XPUB = "xpub6C1dUaopHgps6X75i61KaJEDm4qkFeqjhm4by1ebvpgAsKDaEhGLgNX88bvuWPm4rSVe7GsYvQLDAXXLnxNsAbd3VwRihgM3q1kEkixBAbE"
     VAGUE_NESTEDSW1_YPUB = "ypub6XQGbwTMQ46bb391kD2QM9APJ9JC8JhxF1J4qAULysM82Knmnp8YEZ6YbTvEUJPWhcdv6xWtwFzM6mvgFFXGWpq7WPsq1LZcsHo9R97uuE4"
     VAGUE_NATIVESW1_ZPUB = "zpub6s3t4jJ6fCirkdeAcGCSWpUCjEoWdSjwr5Nja522s2puPB8riPi8MdVJrDrZ9G8FSUNRBoxebGNuMa9nXrUAUQGAFNTKdm6pWskYrMahu1i"
@@ -184,6 +189,7 @@ def tdata(mocker):
             "TAPROOT1_KEY",
             "MINISCRIPT_NATIVESW1_KEY",
             "MINISCRIPT_TAPROOT1_KEY",
+            "SILENT_PAYMENT_KEY",
             "VAGUE_LEGACY1_XPUB",
             "VAGUE_NESTEDSW1_YPUB",
             "VAGUE_NATIVESW1_ZPUB",
@@ -239,6 +245,7 @@ def tdata(mocker):
         TAPROOT1_KEY,
         MINISCRIPT_NATIVESW1_KEY,
         MINISCRIPT_TAPROOT1_KEY,
+        SILENT_PAYMENT_KEY,
         VAGUE_LEGACY1_XPUB,
         VAGUE_NESTEDSW1_YPUB,
         VAGUE_NATIVESW1_ZPUB,

--- a/tests/pages/home_pages/test_pub_key_view.py
+++ b/tests/pages/home_pages/test_pub_key_view.py
@@ -972,3 +972,32 @@ def test_public_key_save_qr_codes_pbm_43(
 
         mock_save_file.assert_has_calls(sd_card_save_calls, any_order=True)
         assert ctx.input.wait_for_button.call_count == len(case[1])
+
+
+def test_public_key_silent_payment(
+    mocker, m5stickv, tdata, mock_save_file, mock_seed_qr_view
+):
+    from krux.pages.home_pages.pub_key_view import PubkeyView
+    from krux.pages import MENU_CONTINUE
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = [
+        BUTTON_ENTER,  # Enter "SPSCAN - Text"
+        BUTTON_ENTER,  # Select "Save to SD card"
+        BUTTON_PAGE,  # Move to "SPSCAN - QR Code"
+        BUTTON_ENTER,  # Enter "SPSCAN - QR Code"
+        BUTTON_PAGE_PREV,  # Move to Back
+        BUTTON_ENTER,  # Leave the page
+    ]
+
+    wallet = Wallet(tdata.SILENT_PAYMENT_KEY)
+    ctx = create_ctx(mocker, BTN_SEQUENCE, wallet=wallet)
+    pub_key_viewer = PubkeyView(ctx)
+
+    assert pub_key_viewer.public_key() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+    # the SPSCAN text was offered to be saved to SD card
+    mock_save_file.assert_called_once()
+    # the descriptor QR code was shown
+    mock_seed_qr_view.assert_called_once()

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -1796,3 +1796,31 @@ def test_load_default_wallet(mocker, amigo):
         assert ctx.wallet.key.policy_type == case[3]
         assert ctx.wallet.key.script_type == case[4]
         assert ctx.wallet.key.derivation == case[5]
+
+
+def test_load_wallet_silent_payment_policy(amigo, mocker):
+    from krux.pages.login import Login
+    from krux.krux_settings import Settings
+    from krux.key import NAME_SILENT_PAYMENT, TYPE_SILENT_PAYMENT, P2TR
+    from krux.input import BUTTON_ENTER
+
+    original_policy = Settings().wallet.policy_type
+    Settings().wallet.policy_type = NAME_SILENT_PAYMENT
+    try:
+        BTN_SEQUENCE = [
+            BUTTON_ENTER,  # Confirm words
+            BUTTON_ENTER,  # Load Wallet
+        ]
+        MNEMONIC = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo daring"
+
+        ctx = create_ctx(mocker, BTN_SEQUENCE)
+        login = Login(ctx)
+        login._load_key_from_words(MNEMONIC.split())
+
+        assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+        # Silent Payment policy forces the P2TR script type
+        assert ctx.wallet.is_silent_payment()
+        assert ctx.wallet.key.policy_type == TYPE_SILENT_PAYMENT
+        assert ctx.wallet.key.script_type == P2TR
+    finally:
+        Settings().wallet.policy_type = original_policy

--- a/tests/pages/test_utils.py
+++ b/tests/pages/test_utils.py
@@ -49,3 +49,16 @@ def test_load_file_with_no_sd(m5stickv, mocker):
 
     assert file_name == ""
     assert data is None
+
+
+def test_generate_wallet_info_silent_payment(m5stickv, mocker):
+    from krux.pages.utils import Utils
+    from krux.key import TYPE_SILENT_PAYMENT, P2TR, NAME_SILENT_PAYMENT
+
+    ctx = create_ctx(mocker, None)
+    utils = Utils(ctx)
+    wallet_info = utils.generate_wallet_info(
+        "Testnet", TYPE_SILENT_PAYMENT, P2TR, "m/352h/1h/0h"
+    )
+
+    assert NAME_SILENT_PAYMENT in wallet_info

--- a/tests/pages/test_wallet_settings.py
+++ b/tests/pages/test_wallet_settings.py
@@ -1049,3 +1049,54 @@ def test_change_derivation_path_not_hardened_node(amigo, mocker, tdata):
     assert ctx.wallet.key.derivation_str() == "m/48h/0h/0h/2"
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
     wallet_settings.prompt.assert_has_calls(prompt_calls)
+
+
+def test_derivation_path_str_silent_payment(m5stickv, mocker):
+    from krux.pages.wallet_settings import WalletSettings
+    from krux.key import TYPE_SILENT_PAYMENT, P2TR
+    from embit.networks import NETWORKS
+
+    ctx = create_ctx(mocker, None)
+    wallet_settings = WalletSettings(ctx)
+
+    # Mainnet uses coin type 0, testnet uses coin type 1
+    assert (
+        wallet_settings._derivation_path_str(
+            TYPE_SILENT_PAYMENT, P2TR, NETWORKS["main"], 0
+        )
+        == "m/352h/0h/0h"
+    )
+    assert (
+        wallet_settings._derivation_path_str(
+            TYPE_SILENT_PAYMENT, P2TR, NETWORKS["test"], 0
+        )
+        == "m/352h/1h/0h"
+    )
+
+
+def test_change_to_silent_payment_policy(m5stickv, mocker, tdata):
+    from krux.pages.wallet_settings import WalletSettings
+    from krux.wallet import Wallet
+    from krux.key import TYPE_SILENT_PAYMENT, P2TR
+    from krux.pages import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = [
+        BUTTON_PAGE,  # Go to "Policy Type"
+        BUTTON_ENTER,  # Enter "Policy Type"
+        *([BUTTON_PAGE] * 3),  # Change to Silent Payment
+        BUTTON_ENTER,  # Confirm Silent Payment
+        BUTTON_PAGE_PREV,  # Go to Back
+        BUTTON_ENTER,  # Leave
+    ]
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE, Wallet(tdata.SINGLESIG_12_WORD_KEY))
+    wallet_settings = WalletSettings(ctx)
+    network, policy_type, script_type, account, derivation_path = (
+        wallet_settings.customize_wallet(ctx.wallet.key)
+    )
+
+    # SP forces P2TR script type and the BIP-352 derivation
+    assert policy_type == TYPE_SILENT_PAYMENT
+    assert script_type == P2TR
+    assert derivation_path == "m/352h/0h/0h"
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -90,11 +90,11 @@ def test_init_fail_unknown_policy_type(mocker, m5stickv, tdata):
     from krux.key import Key
 
     # Assuming that the policy type is an integer
-    # and that the valid types are 0, 1, and 2
-    # (TYPE_SINGLESIG, TYPE_MULTISIG, TYPE_MINISCRIPT)
-    # let's say that 3 is an unknown policy type,
+    # and that the valid types are 0, 1, 2 and 3
+    # (TYPE_SINGLESIG, TYPE_MULTISIG, TYPE_MINISCRIPT, TYPE_SILENT_PAYMENT)
+    # let's say that 4 is an unknown policy type,
     # not supported by the Key class.
-    UNKNOWN_POLICY_TYPE = 3
+    UNKNOWN_POLICY_TYPE = 4
 
     # It should raise a ValueError
     # when a non-supported policy type is passed
@@ -564,6 +564,28 @@ def test_init(mocker, m5stickv, tdata):
         assert key.derivation == case[1]["derivation"]
         assert key.account.to_base58() == case[1]["xpub"]
         n += 1
+
+
+def test_init_silent_payment(mocker, m5stickv, tdata):
+    mock_modules(mocker)
+    from embit.networks import NETWORKS
+    from krux.key import Key, TYPE_SILENT_PAYMENT, P2TR
+
+    key = Key(tdata.TEST_12_WORD_MNEMONIC, TYPE_SILENT_PAYMENT, NETWORKS["test"])
+
+    assert key.policy_type == TYPE_SILENT_PAYMENT
+    assert key.script_type == P2TR
+    assert key.derivation == "m/352h/1h/0h"
+    assert key.sp_keys.scan_privkey is not None
+    assert key.sp_keys.spend_pubkey is not None
+
+    address = key.sp_address("test")
+    assert address.startswith("tsp1")
+
+    spscan = key.sp_scan_key_encoded("test")
+    # key expression includes [fingerprint/derivation] prefix
+    assert "]tspscan1" in spscan
+    assert spscan.startswith("[")
 
 
 def test_xpub(mocker, m5stickv, tdata):

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -20,6 +20,7 @@ def tdata(mocker):
         TYPE_SINGLESIG,
         TYPE_MULTISIG,
         TYPE_MINISCRIPT,
+        TYPE_SILENT_PAYMENT,
     )
 
     TEST_MNEMONIC1 = (
@@ -511,6 +512,68 @@ def test_init_miniscript(mocker, m5stickv, tdata):
     assert wallet.descriptor is None
     assert wallet.label is None
     assert wallet.policy is None
+
+
+def test_init_silent_payment(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.key import Key, TYPE_SILENT_PAYMENT, P2TR
+    from embit.networks import NETWORKS
+
+    key = Key(
+        "olympic term tissue route sense program under choose bean emerge velvet absurd",
+        TYPE_SILENT_PAYMENT,
+        NETWORKS["test"],
+    )
+    wallet = Wallet(key)
+
+    assert isinstance(wallet, Wallet)
+    assert wallet.is_silent_payment()
+    assert not wallet.is_multisig()
+    assert not wallet.is_miniscript()
+    assert wallet.has_change_addr() is False
+    assert wallet.label == "Single-sig SP"
+    assert wallet.policy == {"type": P2TR}
+    assert wallet.descriptor is not None
+
+    addresses = list(wallet.obtain_addresses(i=0, limit=1))
+    assert len(addresses) == 1
+    assert addresses[0].startswith("tsp1")
+
+    addresses_from_1 = list(wallet.obtain_addresses(i=1, limit=1))
+    assert len(addresses_from_1) == 0
+
+
+def test_silent_payment_load_rejected(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.key import Key, TYPE_SILENT_PAYMENT
+    from embit.networks import NETWORKS
+
+    key = Key(
+        "olympic term tissue route sense program under choose bean emerge velvet absurd",
+        TYPE_SILENT_PAYMENT,
+        NETWORKS["test"],
+    )
+    wallet = Wallet(key)
+
+    with pytest.raises(ValueError, match="SP wallets do not load external descriptors"):
+        wallet.load("some wallet data", 0)
+
+
+def test_determine_descriptor_policy_silent_payment(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.key import Key, TYPE_SILENT_PAYMENT, P2TR
+    from embit.networks import NETWORKS
+
+    key = Key(
+        "olympic term tissue route sense program under choose bean emerge velvet absurd",
+        TYPE_SILENT_PAYMENT,
+        NETWORKS["test"],
+    )
+    wallet = Wallet(key)
+
+    policy_type, script_type = wallet._determine_descriptor_policy(wallet.descriptor)
+    assert policy_type == TYPE_SILENT_PAYMENT
+    assert script_type == P2TR
 
 
 def test_is_multisig(mocker, m5stickv, tdata):
@@ -1982,3 +2045,36 @@ def test_wallet_load_rejects_descriptor_m_greater_than_n(mocker, m5stickv):
     wallet = Wallet(None)
     with pytest.raises(ValueError, match="m .* exceeds n"):
         wallet.load("fake_data", 0)
+
+
+def test_silent_payment_obtain_sp_address(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.key import Key, TYPE_SILENT_PAYMENT
+    from embit.networks import NETWORKS
+
+    key = Key(
+        "olympic term tissue route sense program under choose bean emerge velvet absurd",
+        TYPE_SILENT_PAYMENT,
+        NETWORKS["test"],
+    )
+    wallet = Wallet(key)
+
+    address = wallet.obtain_sp_address()
+    assert address == wallet._sp_address
+    assert address.startswith("tsp1")
+
+
+def test_silent_payment_validate_xpub_match_skipped(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.key import Key, TYPE_SILENT_PAYMENT
+    from embit.networks import NETWORKS
+
+    key = Key(
+        "olympic term tissue route sense program under choose bean emerge velvet absurd",
+        TYPE_SILENT_PAYMENT,
+        NETWORKS["test"],
+    )
+    wallet = Wallet(key)
+
+    # SP wallets validate via the scan key, not an xpub, so this returns without error
+    assert wallet._validate_xpub_match(wallet.descriptor, []) is None


### PR DESCRIPTION
### What is this PR for?
This PR adds support for Silent Payment addresses and descriptors, along with a new policy type specifically for Silent Payments: Single-sig SP.


### How to test it?
- Import the same mnemonic into the latest version of Sparrow Wallet (v2.5.1).
- Create or import a watch-only Silent Payment wallet using the spscan(xpub) descriptor.
- Verify that the generated Silent Payment address matches the one shown in Krux.
- Cross-check the descriptor and address derivation between both applications to ensure they are consistent.


### Changes made to:
- [X] Code
- [x] Tests

### Did you build the code and tested on device?
- [X] Yes, build and tested on emulator(MaixPy Amigo)

### What is the purpose of this pull request?
- [X] New feature


https://github.com/user-attachments/assets/3b2826bd-b1e2-43a0-8b5a-4d16ed852a61


