### PR TITLE
Remove polyfill.io from extra_javascript

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,6 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML
 


### PR DESCRIPTION
### What is this PR for?

Remove polyfill from Krux website because of a supply chain attack

<img width="1245" height="354" alt="Captura de tela de 2026-06-06 15-12-30" src="https://github.com/user-attachments/assets/4876ceb2-4769-4c8d-8ce1-4bdf423ad602" />

<img width="940" height="159" alt="Captura de tela de 2026-06-06 15-15-05" src="https://github.com/user-attachments/assets/a1a09c92-c8b2-4ee4-8161-56327a88c5b6" />

Sources:
[Understanding the Polyfill.io Supply Chain Attack and Its Impact](https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack)



### Changes made to:
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
