### PR TITLE
Make settings reads non-mutating and harden malformed settings handling

### DIFF
--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -215,16 +215,17 @@ class Store:
             pass
 
     def get(self, namespace, setting_name, default_value):
-        """Returns a setting value under the given namespace, or default value if not set"""
-        s = json.loads(
-            json.dumps(self.settings)
-        )  # deepcopy to avoid building out namespaces
+        """Returns a setting value under the given namespace, or default value if not set.
+
+        Read-only walk: never mutates self.settings, so no defensive copy is
+        needed. A missing or non-dict intermediate namespace returns the default.
+        """
+        s = self.settings
         for level in namespace.split("."):
-            s[level] = s.get(level, {})
-            s = s[level]
-        if setting_name not in s:
-            return default_value
-        return s[setting_name]
+            s = s.get(level)
+            if not isinstance(s, dict):
+                return default_value
+        return s.get(setting_name, default_value)
 
     def set(self, namespace, setting_name, setting_value):
         """Stores a setting value under the given namespace if new/changed.

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -170,11 +170,7 @@ class Store:
         self._load_settings()
 
         # Define location based on what was loaded or default undefined
-        self.file_location = (
-            self.settings.get("settings", {})
-            .get("persist", {})
-            .get("location", "undefined")
-        )
+        self.file_location = self._persisted_location("undefined")
 
         # Settings not found on SD, or 'persist.location' key not defined
         if SD_PATH not in self.file_location:
@@ -184,10 +180,25 @@ class Store:
 
         # Settings persist location will point to SD (if defined) else defaults to flash
         self.file_location = Store.get_vfs_location(
-            self.settings.get("settings", {})
-            .get("persist", {})
-            .get("location", FLASH_PATH)
+            self._persisted_location(FLASH_PATH)
         )
+
+    def _persisted_location(self, default):
+        """Reads settings.persist.location from a possibly-malformed settings dict.
+
+        The persisted file is only validated to be a top-level dict on load, so a
+        hand-edited/corrupted file may have a non-dict where a namespace is
+        expected. Walk defensively and fall back to the default instead of
+        raising during construction.
+        """
+        node = self.settings
+        for level in ("settings", "persist"):
+            if not isinstance(node, dict):
+                return default
+            node = node.get(level)
+        if not isinstance(node, dict):
+            return default
+        return node.get("location", default)
 
     @classmethod
     def get_vfs_location(cls, location):

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -184,13 +184,9 @@ class Store:
         )
 
     def _persisted_location(self, default):
-        """Reads settings.persist.location from a possibly-malformed settings dict.
-
-        The persisted file is only validated to be a top-level dict on load, so a
-        hand-edited/corrupted file may have a non-dict where a namespace is
-        expected, or a bogus location value. Walk defensively and return only a
-        known location (SD_PATH/FLASH_PATH); otherwise fall back to the default.
-        """
+        """Reads persist.location defensively; returns a known path or default."""
+        # A corrupted/hand-edited file may have a non-dict at any namespace level
+        # or a bogus location value — walk defensively and validate before returning.
         node = self.settings
         for level in ("settings", "persist"):
             if not isinstance(node, dict):
@@ -229,11 +225,7 @@ class Store:
             pass
 
     def get(self, namespace, setting_name, default_value):
-        """Returns a setting value under the given namespace, or default value if not set.
-
-        Read-only walk: never mutates self.settings, so no defensive copy is
-        needed. A missing or non-dict intermediate namespace returns the default.
-        """
+        """Returns setting value under the given namespace, or default_value if not set."""
         s = self.settings
         for level in namespace.split("."):
             s = s.get(level)
@@ -242,13 +234,9 @@ class Store:
         return s.get(setting_name, default_value)
 
     def set(self, namespace, setting_name, setting_value):
-        """Stores a setting value under the given namespace if new/changed.
-        Does NOT automatically save settings to flash or sd!
-
-        A non-dict intermediate level (from a corrupted/hand-edited file) is
-        replaced with a fresh dict, so writing a setting cannot raise and also
-        repairs the malformed structure.
-        """
+        """Stores a setting value under the given namespace if new/changed. Does not auto-save."""
+        # A non-dict intermediate level is replaced with a fresh dict,
+        # repairing malformed structure.
         s = self.settings
         for level in namespace.split("."):
             if not isinstance(s.get(level), dict):

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -188,8 +188,8 @@ class Store:
 
         The persisted file is only validated to be a top-level dict on load, so a
         hand-edited/corrupted file may have a non-dict where a namespace is
-        expected. Walk defensively and fall back to the default instead of
-        raising during construction.
+        expected, or a bogus location value. Walk defensively and return only a
+        known location (SD_PATH/FLASH_PATH); otherwise fall back to the default.
         """
         node = self.settings
         for level in ("settings", "persist"):
@@ -198,7 +198,10 @@ class Store:
             node = node.get(level)
         if not isinstance(node, dict):
             return default
-        return node.get("location", default)
+        location = node.get("location", default)
+        if location not in (SD_PATH, FLASH_PATH):
+            return default
+        return location
 
     @classmethod
     def get_vfs_location(cls, location):

--- a/src/krux/settings.py
+++ b/src/krux/settings.py
@@ -244,10 +244,15 @@ class Store:
     def set(self, namespace, setting_name, setting_value):
         """Stores a setting value under the given namespace if new/changed.
         Does NOT automatically save settings to flash or sd!
+
+        A non-dict intermediate level (from a corrupted/hand-edited file) is
+        replaced with a fresh dict, so writing a setting cannot raise and also
+        repairs the malformed structure.
         """
         s = self.settings
         for level in namespace.split("."):
-            s[level] = s.get(level, {})
+            if not isinstance(s.get(level), dict):
+                s[level] = {}
             s = s[level]
         old_value = s.get(setting_name, None)
         if old_value != setting_value:
@@ -261,7 +266,8 @@ class Store:
         s = self.settings
         levels = []
         for level in namespace.split("."):
-            s[level] = s.get(level, {})
+            if not isinstance(s.get(level), dict):
+                s[level] = {}
             levels.append([s, level])
             s = s[level]
         if setting_name in s:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -307,6 +307,33 @@ def test_store_init_survives_non_dict_settings_namespace(mocker, m5stickv):
     assert store.get("settings.i18n", "locale", "en-US") == "en-US"
 
 
+def test_store_init_survives_bogus_persist_location(mocker, m5stickv):
+    """Store.__init__ must not crash on a bogus persist.location value.
+
+    The structure is well-formed but `location` holds an unexpected value
+    (non-string, or an unknown string). `_persisted_location` must return only a
+    known location (SD/flash) and otherwise fall back to the default, so the
+    `SD_PATH not in self.file_location` membership test never sees a non-string.
+    """
+    from krux.settings import Store, FLASH_PATH
+
+    # Non-string location (would raise "argument of type 'int' is not iterable").
+    mocker.patch(
+        "builtins.open",
+        mocker.mock_open(read_data='{"settings": {"persist": {"location": 123}}}'),
+    )
+    store = Store()  # must not raise
+    assert FLASH_PATH in store.file_location
+
+    # Unknown string location -> also falls back to flash.
+    mocker.patch(
+        "builtins.open",
+        mocker.mock_open(read_data='{"settings": {"persist": {"location": "xyz"}}}'),
+    )
+    store = Store()  # must not raise
+    assert FLASH_PATH in store.file_location
+
+
 def test_store_get_recovers_from_malformed_persisted_namespace(mocker, m5stickv):
     """End-to-end: a persisted settings file with a well-formed top level but a
     non-dict nested namespace loads, and reads through it degrade gracefully.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -265,6 +265,46 @@ def test_store_get():
         assert s.get(case[0], case[1], case[3]) == case[2]
 
 
+def test_store_get_malformed_namespace_returns_default():
+    """A non-dict intermediate namespace must return the default, not raise.
+
+    Covers BOTH a non-dict at the first level AND a non-dict reached after a
+    valid descent (proves traversal stays safe mid-walk). Only reachable via a
+    corrupted/hand-edited settings file; set() never creates this state.
+    Approved behavior change: graceful degradation.
+    """
+    from krux.settings import Store
+
+    s = Store()
+
+    # Case 1: non-dict at the very first level.
+    s.settings = {"settings": "not_a_dict"}
+    assert s.get("settings.i18n", "locale", "en-US") == "en-US"
+    assert s.settings == {"settings": "not_a_dict"}  # no mutation
+
+    # Case 2: non-dict reached AFTER successfully descending a valid dict.
+    s.settings = {"settings": {"printer": "not_a_dict"}}
+    assert s.get("settings.printer.thermal", "baudrate", 9600) == 9600
+    assert s.settings == {"settings": {"printer": "not_a_dict"}}  # no mutation
+
+
+def test_store_get_deep_nesting():
+    """A 4-level namespace returns stored value when set, default when unset."""
+    from krux.settings import Store
+
+    s = Store()
+    ns = "settings.printer.thermal.adafruit"
+
+    # Unset -> default.
+    assert s.get(ns, "tx_pin", 35) == 35
+    # Getter must not populate the settings dict on a miss.
+    assert s.settings == {}
+
+    # Set then get returns the stored value, ignoring the default.
+    s.set(ns, "tx_pin", 21)
+    assert s.get(ns, "tx_pin", 35) == 21
+
+
 def test_store_set():
     from krux.settings import Store
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -288,6 +288,39 @@ def test_store_get_malformed_namespace_returns_default():
     assert s.settings == {"settings": {"printer": "not_a_dict"}}  # no mutation
 
 
+def test_store_set_repairs_non_dict_namespace(mocker, m5stickv):
+    """Store.set must not crash when an intermediate namespace is a non-dict
+    (e.g. a corrupted file like {"settings": "broken"}); it replaces the bad
+    level with a dict, stores the value, and repairs the structure.
+    """
+    from krux.settings import Store
+
+    s = Store()
+    s.settings = {"settings": "broken"}
+
+    # Pre-fix this raised AttributeError: 'str' object has no attribute 'get'.
+    s.set("settings.appearance", "theme", "dark")
+
+    assert s.settings["settings"]["appearance"]["theme"] == "dark"
+    assert s.dirty is True
+    # Read-back through the repaired structure returns the stored value.
+    assert s.get("settings.appearance", "theme", "light") == "dark"
+
+
+def test_store_delete_survives_non_dict_namespace(mocker, m5stickv):
+    """Store.delete must not crash when an intermediate namespace is a non-dict."""
+    from krux.settings import Store
+
+    s = Store()
+    s.settings = {"settings": "broken"}
+
+    # Pre-fix this raised AttributeError walking into the string "broken".
+    s.delete("settings.appearance", "theme")  # nothing to delete, must not raise
+    # The non-dict "broken" must no longer be present (repaired, then the empty
+    # levels cleaned up by delete's own pruning).
+    assert s.settings.get("settings") != "broken"
+
+
 def test_store_init_survives_non_dict_settings_namespace(mocker, m5stickv):
     """Store.__init__ must not crash when the persisted 'settings' value is a
     non-dict.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -288,6 +288,45 @@ def test_store_get_malformed_namespace_returns_default():
     assert s.settings == {"settings": {"printer": "not_a_dict"}}  # no mutation
 
 
+def test_store_init_survives_non_dict_settings_namespace(mocker, m5stickv):
+    """Store.__init__ must not crash when the persisted 'settings' value is a
+    non-dict.
+
+    The loader only validates the top level is a dict, so a corrupted file like
+    {"settings": "not_a_dict"} passes load. The location read in __init__ walks
+    settings.persist.location and must degrade gracefully instead of raising
+    AttributeError. Reads through the malformed namespace return defaults.
+    """
+    stored_settings = '{"settings": "not_a_dict"}'
+    mocker.patch("builtins.open", mocker.mock_open(read_data=stored_settings))
+
+    from krux.settings import Store, FLASH_PATH
+
+    store = Store()  # must not raise
+    assert FLASH_PATH in store.file_location
+    assert store.get("settings.i18n", "locale", "en-US") == "en-US"
+
+
+def test_store_get_recovers_from_malformed_persisted_namespace(mocker, m5stickv):
+    """End-to-end: a persisted settings file with a well-formed top level but a
+    non-dict nested namespace loads, and reads through it degrade gracefully.
+
+    The top level, `settings`, and `settings.persist` are well-formed (the
+    constructor reads `persist` to pick the file location), but the `i18n`
+    namespace is a string instead of a dict. get() must return the default
+    rather than raising. Covers the file -> __init__ -> get() chain, not just
+    direct Store.get() calls.
+    """
+    stored_settings = '{"settings": {"i18n": "not_a_dict"}}'
+    mocker.patch("builtins.open", mocker.mock_open(read_data=stored_settings))
+
+    from krux.settings import Store
+
+    store = Store()
+    assert store.settings == {"settings": {"i18n": "not_a_dict"}}
+    assert store.get("settings.i18n", "locale", "en-US") == "en-US"
+
+
 def test_store_get_deep_nesting():
     """A 4-level namespace returns stored value when set, default when unset."""
     from krux.settings import Store


### PR DESCRIPTION
### What is this PR for?
Makes the settings store safer and lighter. Store.get() reads without JSON-copying the whole settings tree, and a corrupted settings file is handled instead of crashing (at boot, on read, and on write, where it also repairs itself). Valid settings behave exactly the same.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [x] Yes, build and tested on Maix Amigo

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other (small refactor of Store.get)

Testing: full test suite green (1089), lint 10/10. New tests fail on the old code. On the Amigo: settings save and load on flash and SD persist across restart, a corrupted settings file boots to defaults, and editing a setting with that corrupt file saves fine and repairs it.