### PR TITLE
refactor: remove duplicated work in display orientation/init paths

### DIFF
--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -244,20 +244,14 @@ class Display:
     def to_landscape(self):
         """Changes the rotation of the display to landscape"""
         if self.portrait:
-            hardware = Settings().hardware
-            flipped = hasattr(hardware, "display") and getattr(
-                hardware.display, "flipped_orientation", False
-            )
+            flipped = Settings().is_flipped_orientation()
             lcd.rotation((LANDSCAPE + 2) % 4 if flipped else LANDSCAPE)
             self.portrait = False
 
     def to_portrait(self):
         """Changes the rotation of the display to portrait"""
         if not self.portrait:
-            hardware = Settings().hardware
-            flipped = hasattr(hardware, "display") and getattr(
-                hardware.display, "flipped_orientation", False
-            )
+            flipped = Settings().is_flipped_orientation()
             lcd.rotation((PORTRAIT + 2) % 4 if flipped else PORTRAIT)
             self.portrait = True
 

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -167,9 +167,10 @@ class Display:
                 offset_h0=80,
             )
         elif kboard.is_amigo:
-            lcd_type = Settings().hardware.display.lcd_type
-            invert = Settings().hardware.display.inverted_colors
-            bgr_to_rgb = Settings().hardware.display.bgr_colors
+            display_settings = Settings().hardware.display
+            lcd_type = display_settings.lcd_type
+            invert = display_settings.inverted_colors
+            bgr_to_rgb = display_settings.bgr_colors
             lcd.init(invert=invert, lcd_type=lcd_type)
             lcd.mirror(True)
             lcd.bgr_to_rgb(bgr_to_rgb)
@@ -243,23 +244,21 @@ class Display:
     def to_landscape(self):
         """Changes the rotation of the display to landscape"""
         if self.portrait:
-            lcd.rotation(
-                (LANDSCAPE + 2) % 4
-                if hasattr(Settings().hardware, "display")
-                and getattr(Settings().hardware.display, "flipped_orientation", False)
-                else LANDSCAPE
+            hardware = Settings().hardware
+            flipped = hasattr(hardware, "display") and getattr(
+                hardware.display, "flipped_orientation", False
             )
+            lcd.rotation((LANDSCAPE + 2) % 4 if flipped else LANDSCAPE)
             self.portrait = False
 
     def to_portrait(self):
         """Changes the rotation of the display to portrait"""
         if not self.portrait:
-            lcd.rotation(
-                (PORTRAIT + 2) % 4
-                if hasattr(Settings().hardware, "display")
-                and getattr(Settings().hardware.display, "flipped_orientation", False)
-                else PORTRAIT
+            hardware = Settings().hardware
+            flipped = hasattr(hardware, "display") and getattr(
+                hardware.display, "flipped_orientation", False
             )
+            lcd.rotation((PORTRAIT + 2) % 4 if flipped else PORTRAIT)
             self.portrait = True
 
     def _usable_pixels_in_line(self):

--- a/src/krux/krux_settings.py
+++ b/src/krux/krux_settings.py
@@ -502,8 +502,8 @@ class Settings(SettingsNamespace):
 
     def is_flipped_orientation(self):
         """Returns flipped orientation setting"""
-        return hasattr(Settings().hardware, "display") and getattr(
-            Settings().hardware.display, "flipped_orientation", False
+        return hasattr(self.hardware, "display") and getattr(
+            self.hardware.display, "flipped_orientation", False
         )
 
     def label(self, attr):


### PR DESCRIPTION
### What is this PR for?

Cleanup-only refactor of the display orientation/init paths. Behavior is unchanged.

- Read Settings() once in the orientation/init paths instead of rebuilding it repeatedly.
- Reuse the existing is_flipped_orientation helper instead of a duplicated check.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, built and tested on the Yahboom. Boots normally. Display flips 180 degrees and reverts back correctly.

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other