### PR TITLE
refactor: dedupe flipped-orientation check in touch.py via is_flipped_orientation

### DIFF
--- a/src/krux/touch.py
+++ b/src/krux/touch.py
@@ -93,9 +93,7 @@ class Touch:
     def valid_position(self, data):
         """Checks if touch position is within buttons area"""
 
-        if hasattr(Settings().hardware, "display") and getattr(
-            Settings().hardware.display, "flipped_orientation", False
-        ):
+        if Settings().is_flipped_orientation():
             data = (self.height - data[0], self.width - data[1])
 
         if self.x_regions and data[0] < self.x_regions[0]:
@@ -189,9 +187,7 @@ class Touch:
     def _store_points(self, data):
         """Store pressed points and calculare an average pressed point"""
 
-        if hasattr(Settings().hardware, "display") and getattr(
-            Settings().hardware.display, "flipped_orientation", False
-        ):
+        if Settings().is_flipped_orientation():
             new_y = max(0, self.height - data[0])
             new_y = min(new_y, self.height - 1)
             new_x = max(0, self.width - data[1])

--- a/tests/test_touch.py
+++ b/tests/test_touch.py
@@ -7,8 +7,8 @@ def mock_settings(mocker):
     """Mock Settings to avoid dependency on hardware config"""
     mock_settings_obj = mocker.MagicMock()
     mock_settings_obj.hardware.touch.threshold = 40
-    # Ensure hardware doesn't have display attribute to avoid coordinate flipping
-    del mock_settings_obj.hardware.display
+    # Default to no coordinate flipping
+    mock_settings_obj.is_flipped_orientation.return_value = False
     mock_settings_class = mocker.patch("krux.touch.Settings")
     mock_settings_class.return_value = mock_settings_obj
     return mock_settings_obj


### PR DESCRIPTION
### What is this PR for?

Follow-up to #878. Applies the same optimization in touch.py: replaces the duplicated inline flipped-orientation check in valid_position() and _store_points() with the existing Settings().is_flipped_orientation() helper. 

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [x] Yes, built and tested on Yahboom

Taps land correctly, and swipes work in both normal and flipped orientation.

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other (refactor / dedup)