### PR TITLE
perf: cache Settings() namespace tree as a singleton

### DIFF
--- a/src/krux/krux_settings.py
+++ b/src/krux/krux_settings.py
@@ -490,8 +490,19 @@ class Settings(SettingsNamespace):
     """The top-level settings namespace under which other namespaces reside"""
 
     namespace = "settings"
+    _instance = None
+
+    def __new__(cls):
+        # Cache the namespace tree: values are read live from the `store`
+        # singleton, so reusing the instance avoids rebuilding ~16 objects
+        # on every Settings() call without staling any setting.
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __init__(self):
+        if getattr(self, "_built", False):
+            return
         self.wallet = DefaultWallet()
         self.security = SecuritySettings()
         self.hardware = HardwareSettings()
@@ -499,6 +510,7 @@ class Settings(SettingsNamespace):
         self.encryption = EncryptionSettings()
         self.persist = PersistSettings()
         self.appearance = ThemeSettings()
+        self._built = True
 
     def is_flipped_orientation(self):
         """Returns flipped orientation setting"""

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -10,6 +10,7 @@ def mocker_printer(mocker):
 @pytest.fixture
 def mock_retro_compatibility(mocker, amigo):
     from krux.settings import CategorySetting
+    from krux.krux_settings import Settings
 
     class MockDefaultWallet:
         namespace = "settings.wallet"
@@ -24,6 +25,10 @@ def mock_retro_compatibility(mocker, amigo):
         "krux.krux_settings.DefaultWallet",
         mocker.MagicMock(return_value=MockDefaultWallet()),
     )
+    # Settings caches its namespace tree, which may already have been built
+    # (e.g. via krux.themes at import). Drop the cache so the next Settings()
+    # rebuilds with the patched DefaultWallet.
+    mocker.patch.object(Settings, "_instance", None)
 
 
 ################### Test menus


### PR DESCRIPTION
### What is this PR for?
Following @kkdao 's settings optimizations, this one cache Settings() namespace tree as a singleton and avoids rebuilding multiple namespace objects on every Settings() call


### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on Amigo and WonderMV

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
