### PR TITLE
fix: handle encrypted mnemonic storage edge cases

### DIFF
--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -36,18 +36,23 @@ QR_CODE_ITER_MULTIPLE = 10000
 class MnemonicStorage:
     """Handler of stored encrypted seeds"""
 
+    @staticmethod
+    def _load_mnemonics(contents):
+        mnemonics = json.loads(contents)
+        return mnemonics if isinstance(mnemonics, dict) else {}
+
     def __init__(self) -> None:
         self.stored = {}
         self.stored_sd = {}
         try:
             with SDHandler() as sd:
-                self.stored_sd = json.loads(sd.read(MNEMONICS_FILE))
+                self.stored_sd = self._load_mnemonics(sd.read(MNEMONICS_FILE))
         except (OSError, ValueError):
             # missing/unreadable SD card or malformed JSON -> start empty
             pass
         try:
             with open(FLASH_PATH_STR % MNEMONICS_FILE, "r") as f:
-                self.stored = json.loads(f.read())
+                self.stored = self._load_mnemonics(f.read())
         except (OSError, ValueError):
             # missing/unreadable flash file or malformed JSON -> start empty
             pass
@@ -89,12 +94,10 @@ class MnemonicStorage:
 
     def decrypt(self, key, mnemonic_id, sd_card=False):
         """Decrypt a selected encrypted mnemonic from a file"""
-        try:
-            if sd_card:
-                stored_value = self.stored_sd.get(mnemonic_id)
-            else:
-                stored_value = self.stored.get(mnemonic_id)
-        except:
+        source = self.stored_sd if sd_card else self.stored
+        stored_value = source.get(mnemonic_id) if isinstance(source, dict) else None
+        if not isinstance(stored_value, dict):
+            # unknown id, or a corrupt/non-dict storage entry -> nothing to decrypt
             return None
 
         if stored_value.get("b64_kef"):
@@ -122,7 +125,7 @@ class MnemonicStorage:
                 with SDHandler() as sd:
                     contents = sd.read(MNEMONICS_FILE)
                     orig_len = len(contents)
-                    mnemonics = json.loads(contents)
+                    mnemonics = self._load_mnemonics(contents)
             except (OSError, ValueError):
                 # no existing/readable file or malformed JSON -> write fresh
                 orig_len = 0
@@ -143,7 +146,7 @@ class MnemonicStorage:
             try:
                 # load current MNEMONICS_FILE
                 with open(FLASH_PATH_STR % MNEMONICS_FILE, "r") as f:
-                    mnemonics = json.loads(f.read())
+                    mnemonics = self._load_mnemonics(f.read())
             except (OSError, ValueError):
                 # no existing/readable file or malformed JSON -> write fresh
                 pass

--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -38,8 +38,7 @@ class MnemonicStorage:
 
     @staticmethod
     def _load_mnemonics(contents):
-        mnemonics = json.loads(contents)
-        return mnemonics if isinstance(mnemonics, dict) else {}
+        return json.loads(contents)
 
     def __init__(self) -> None:
         self.stored = {}

--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -33,6 +33,11 @@ FLASH_PATH_STR = "/" + FLASH_PATH + "/%s"
 QR_CODE_ITER_MULTIPLE = 10000
 
 
+class StorageCorruptedError(Exception):
+    """Stored mnemonics file exists but is not a valid object; it is left
+    untouched instead of being overwritten, so its data can be recovered."""
+
+
 class MnemonicStorage:
     """Handler of stored encrypted seeds"""
 
@@ -85,11 +90,11 @@ class MnemonicStorage:
 
     def list_mnemonics(self, sd_card=False):
         """List all seeds stored on a file"""
-        mnemonic_ids = []
         source = self.stored_sd if sd_card else self.stored
-        for mnemonic_id in source:
-            mnemonic_ids.append(mnemonic_id)
-        return mnemonic_ids
+        if not isinstance(source, dict):
+            # corrupt/non-dict storage -> nothing to list
+            return []
+        return list(source)
 
     def decrypt(self, key, mnemonic_id, sd_card=False):
         """Decrypt a selected encrypted mnemonic from a file"""
@@ -120,14 +125,21 @@ class MnemonicStorage:
         mnemonics = {}
         if sd_card:
             # load current MNEMONICS_FILE
+            orig_len = 0
             try:
                 with SDHandler() as sd:
                     contents = sd.read(MNEMONICS_FILE)
                     orig_len = len(contents)
                     mnemonics = self._load_mnemonics(contents)
-            except (OSError, ValueError):
-                # no existing/readable file or malformed JSON -> write fresh
-                orig_len = 0
+            except OSError:
+                # missing file -> write a fresh store
+                pass
+            except ValueError as exc:
+                # corrupt JSON -> preserve for recovery
+                raise StorageCorruptedError(MNEMONICS_FILE) from exc
+            if not isinstance(mnemonics, dict):
+                # wrong shape -> preserve for recovery
+                raise StorageCorruptedError(MNEMONICS_FILE)
 
             # save the new MNEMONICS_FILE
             try:
@@ -146,9 +158,15 @@ class MnemonicStorage:
                 # load current MNEMONICS_FILE
                 with open(FLASH_PATH_STR % MNEMONICS_FILE, "r") as f:
                     mnemonics = self._load_mnemonics(f.read())
-            except (OSError, ValueError):
-                # no existing/readable file or malformed JSON -> write fresh
+            except OSError:
+                # missing file -> write a fresh store
                 pass
+            except ValueError as exc:
+                # corrupt JSON -> preserve for recovery
+                raise StorageCorruptedError(MNEMONICS_FILE) from exc
+            if not isinstance(mnemonics, dict):
+                # wrong shape -> preserve for recovery
+                raise StorageCorruptedError(MNEMONICS_FILE)
             try:
                 # save the new MNEMONICS_FILE
                 with open(FLASH_PATH_STR % MNEMONICS_FILE, "w") as f:

--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -42,12 +42,14 @@ class MnemonicStorage:
         try:
             with SDHandler() as sd:
                 self.stored_sd = json.loads(sd.read(MNEMONICS_FILE))
-        except:
+        except (OSError, ValueError):
+            # missing/unreadable SD card or malformed JSON -> start empty
             pass
         try:
             with open(FLASH_PATH_STR % MNEMONICS_FILE, "r") as f:
                 self.stored = json.loads(f.read())
-        except:
+        except (OSError, ValueError):
+            # missing/unreadable flash file or malformed JSON -> start empty
             pass
 
     def _deprecated_decrypt(self, key, salt, iterations, mode, payload):
@@ -73,6 +75,8 @@ class MnemonicStorage:
             plaintext = kef._unpad(decryptor.decrypt(payload), pkcs_pad=False)
             return plaintext.decode()
         except:
+            # broad on purpose: any failure here means a wrong key or
+            # incompatible legacy ciphertext -> return None
             return None
 
     def list_mnemonics(self, sd_card=False):
@@ -119,7 +123,8 @@ class MnemonicStorage:
                     contents = sd.read(MNEMONICS_FILE)
                     orig_len = len(contents)
                     mnemonics = json.loads(contents)
-            except:
+            except (OSError, ValueError):
+                # no existing/readable file or malformed JSON -> write fresh
                 orig_len = 0
 
             # save the new MNEMONICS_FILE
@@ -132,13 +137,15 @@ class MnemonicStorage:
                         contents += " " * (orig_len - len(contents))
                     sd.write(MNEMONICS_FILE, contents)
             except:
+                # broad on purpose: any failure to save means the store failed
                 return False
         else:
             try:
                 # load current MNEMONICS_FILE
                 with open(FLASH_PATH_STR % MNEMONICS_FILE, "r") as f:
                     mnemonics = json.loads(f.read())
-            except:
+            except (OSError, ValueError):
+                # no existing/readable file or malformed JSON -> write fresh
                 pass
             try:
                 # save the new MNEMONICS_FILE
@@ -146,6 +153,7 @@ class MnemonicStorage:
                     mnemonics[mnemonic_id] = {"b64_kef": b64_kef}
                     f.write(json.dumps(mnemonics))
             except:
+                # broad on purpose: any failure to save means the store failed
                 return False
         return True
 

--- a/src/krux/pages/encryption_ui.py
+++ b/src/krux/pages/encryption_ui.py
@@ -615,7 +615,7 @@ class EncryptMnemonic(Page):
     def store_mnemonic_on_memory(self, sd_card=False):
         """Save encrypted mnemonic on flash or sd_card"""
 
-        from ..encryption import MnemonicStorage
+        from ..encryption import MnemonicStorage, StorageCorruptedError
 
         encrypted_data, mnemonic_id = self._encrypt_mnemonic_with_label()
         if encrypted_data is None:
@@ -629,7 +629,23 @@ class EncryptMnemonic(Page):
             del mnemonic_storage
             return
 
-        if mnemonic_storage.store_encrypted_kef(mnemonic_id, encrypted_data, sd_card):
+        try:
+            stored = mnemonic_storage.store_encrypted_kef(
+                mnemonic_id, encrypted_data, sd_card
+            )
+        except StorageCorruptedError:
+            self.ctx.display.clear()
+            # English-only: rare corruption guard, not worth translating
+            self.ctx.display.draw_centered_text(
+                "Stored seeds file is corrupted and was preserved.\n"
+                "Encrypted mnemonic was not stored.",
+                theme.error_color,
+            )
+            self.ctx.input.wait_for_button()
+            del mnemonic_storage
+            return
+
+        if stored:
             self.ctx.display.clear()
             self.ctx.display.draw_centered_text(
                 t("Encrypted mnemonic stored with ID:") + " " + mnemonic_id,

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -41,7 +41,7 @@ def mock_file_operations(mocker):
         "os.listdir",
         new=mocker.MagicMock(return_value=["somefile", "otherfile"]),
     )
-    mocker.patch("builtins.open", mocker.mock_open(read_data="SEEDS_JSON"))
+    mocker.patch("builtins.open", mocker.mock_open(read_data=SEEDS_JSON))
 
 
 def test_load_key_from_keypad(m5stickv, mocker):
@@ -285,6 +285,49 @@ def test_encrypt_save_error(m5stickv, mocker, mock_file_operations):
 
     ctx.display.draw_centered_text.assert_has_calls(
         [mocker.call("Failed to store mnemonic", theme.error_color)], any_order=True
+    )
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
+def test_encrypt_save_corrupted_file_preserved(m5stickv, mocker, mock_file_operations):
+    from krux.wallet import Wallet
+    from krux.krux_settings import Settings
+    from krux.input import BUTTON_ENTER
+    from krux.pages.encryption_ui import EncryptMnemonic
+    from krux.encryption import StorageCorruptedError
+    from krux.key import Key
+    from embit.networks import NETWORKS
+    from krux.themes import theme
+
+    BTN_SEQUENCE = (
+        [BUTTON_ENTER]  # Confirm flash store
+        + [BUTTON_ENTER]  # Yes, use fingerprint as ID
+        + [BUTTON_ENTER]  # Confirm encryption ID
+    )
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    ctx.wallet = Wallet(Key(ECB_WORDS, False, NETWORKS["main"]))
+    Settings().encryption.version = "AES-ECB"
+    storage_ui = EncryptMnemonic(ctx)
+    mocker.patch(
+        "krux.pages.encryption_ui.EncryptionKey.encryption_key",
+        mocker.MagicMock(return_value=TEST_KEY),
+    )
+    # a corrupt seeds file must not be overwritten: store raises, UI warns
+    mocker.patch(
+        "krux.encryption.MnemonicStorage.store_encrypted_kef",
+        mocker.MagicMock(side_effect=StorageCorruptedError("seeds.json")),
+    )
+    storage_ui.encrypt_menu()
+
+    ctx.display.draw_centered_text.assert_has_calls(
+        [
+            mocker.call(
+                "Stored seeds file is corrupted and was preserved.\n"
+                "Encrypted mnemonic was not stored.",
+                theme.error_color,
+            )
+        ],
+        any_order=True,
     )
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -726,21 +726,35 @@ def test_store_sd_read_oserror_still_writes(m5stickv, mocker, mock_file_operatio
     m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
 
 
-def test_store_sd_read_malformed_json_still_writes(
+def test_store_sd_read_malformed_json_raises_and_preserves(
     m5stickv, mocker, mock_file_operations
 ):
     from krux.krux_settings import Settings
-    from krux.encryption import MnemonicStorage
+    from krux.encryption import MnemonicStorage, StorageCorruptedError
 
     storage = MnemonicStorage()
     Settings().encryption.version = "AES-ECB"
     mocker.patch("krux.sd_card.SDHandler.read", return_value="not valid json {{{")
     with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
-        success = storage.store_encrypted_kef(
-            "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
-        )
-    assert success is True
-    m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+        with pytest.raises(StorageCorruptedError):
+            storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=True)
+    # existing (corrupt-but-recoverable) file must not be overwritten
+    m().write.assert_not_called()
+
+
+def test_store_sd_read_non_dict_json_raises_and_preserves(
+    m5stickv, mocker, mock_file_operations
+):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage, StorageCorruptedError
+
+    storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    mocker.patch("krux.sd_card.SDHandler.read", return_value="[1, 2, 3]")
+    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
+        with pytest.raises(StorageCorruptedError):
+            storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=True)
+    m().write.assert_not_called()
 
 
 # --- store_encrypted_kef flash read-before-write ---
@@ -779,22 +793,24 @@ def test_store_flash_read_oserror_still_writes(m5stickv, mocker):
     write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
 
 
-def test_store_flash_read_malformed_json_still_writes(m5stickv, mocker):
+def test_store_flash_read_malformed_json_raises_and_preserves(m5stickv, mocker):
     from krux.krux_settings import Settings
-    from krux.encryption import MnemonicStorage
+    from krux.encryption import MnemonicStorage, StorageCorruptedError
 
     with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
         storage = MnemonicStorage()
     Settings().encryption.version = "AES-ECB"
     read_handle = mocker.mock_open(read_data="not valid json {{{")
     write_handle = mocker.mock_open()
-    mocker.patch(
+    open_mock = mocker.patch(
         "krux.encryption.open",
         side_effect=[read_handle.return_value, write_handle.return_value],
     )
-    success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
-    assert success is True
-    write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+    with pytest.raises(StorageCorruptedError):
+        storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+    # file opened for read only; never opened for write (no truncation)
+    assert open_mock.call_count == 1
+    write_handle().write.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -825,3 +841,52 @@ def test_decrypt_non_dict_storage_returns_none(m5stickv, mocker):
         storage = MnemonicStorage()
     assert storage.stored == [1, 2, 3]
     assert storage.decrypt("any-key", "any-id", sd_card=False) is None
+
+
+# list_mnemonics() returns [] for non-dict storage instead of iterating it
+# (a list would yield junk ids; a non-iterable like null would raise).
+
+
+def test_list_mnemonics_non_dict_storage_returns_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="[1, 2, 3]")):
+        storage = MnemonicStorage()
+    assert storage.stored == [1, 2, 3]
+    assert storage.list_mnemonics(sd_card=False) == []
+
+
+def test_list_mnemonics_non_iterable_storage_returns_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    # JSON "null" loads to None, which is not iterable -> must not raise
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="null")):
+        storage = MnemonicStorage()
+    assert storage.stored is None
+    assert storage.list_mnemonics(sd_card=False) == []
+
+
+# store_encrypted_kef() raises before opening "w" on a non-dict flash file,
+# so the existing (recoverable) data is never truncated.
+
+
+def test_store_flash_read_non_dict_json_raises_and_preserves(m5stickv, mocker):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage, StorageCorruptedError
+
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    read_handle = mocker.mock_open(read_data="[1, 2, 3]")
+    write_handle = mocker.mock_open()
+    open_mock = mocker.patch(
+        "krux.encryption.open",
+        side_effect=[read_handle.return_value, write_handle.return_value],
+    )
+    with pytest.raises(StorageCorruptedError):
+        storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+    # file opened for read only; never opened for write (no truncation)
+    assert open_mock.call_count == 1
+    write_handle().write.assert_not_called()

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -661,6 +661,19 @@ def test_init_sd_load_malformed_json_starts_empty(m5stickv, mocker):
     assert storage.stored_sd == {}
 
 
+def test_init_sd_load_non_dict_json_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    sd = mocker.MagicMock()
+    sd.read.return_value = "[1, 2, 3]"
+    sdhandler = mocker.MagicMock()
+    sdhandler.return_value.__enter__.return_value = sd
+    mocker.patch("krux.encryption.SDHandler", new=sdhandler)
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    assert storage.stored_sd == {}
+
+
 # --- __init__ flash load (self.stored) ---
 
 
@@ -692,6 +705,16 @@ def test_init_flash_load_malformed_json_starts_empty(m5stickv, mocker):
     ):
         storage = MnemonicStorage()
     assert storage.stored == {}
+
+
+def test_init_flash_load_non_dict_json_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="[1, 2, 3]")):
+        storage = MnemonicStorage()
+    assert storage.stored == {}
+    assert storage.list_mnemonics() == []
 
 
 # --- store_encrypted_kef SD read-before-write ---
@@ -735,6 +758,23 @@ def test_store_sd_read_malformed_json_still_writes(
     storage = MnemonicStorage()
     Settings().encryption.version = "AES-ECB"
     mocker.patch("krux.sd_card.SDHandler.read", return_value="not valid json {{{")
+    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
+        success = storage.store_encrypted_kef(
+            "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
+        )
+    assert success is True
+    m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+def test_store_sd_read_non_dict_json_still_writes(
+    m5stickv, mocker, mock_file_operations
+):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    mocker.patch("krux.sd_card.SDHandler.read", return_value="[1, 2, 3]")
     with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
         success = storage.store_encrypted_kef(
             "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
@@ -795,3 +835,51 @@ def test_store_flash_read_malformed_json_still_writes(m5stickv, mocker):
     success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
     assert success is True
     write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+def test_store_flash_read_non_dict_json_still_writes(m5stickv, mocker):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    read_handle = mocker.mock_open(read_data="[1, 2, 3]")
+    write_handle = mocker.mock_open()
+    mocker.patch(
+        "krux.encryption.open",
+        side_effect=[read_handle.return_value, write_handle.return_value],
+    )
+    success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+    assert success is True
+    write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+# ---------------------------------------------------------------------------
+# decrypt() must not crash on a missing id or non-dict storage.
+#
+# storage.get(id) returns None for an unknown id. decrypt() should return None
+# instead of raising AttributeError when there is no stored entry.
+# ---------------------------------------------------------------------------
+
+
+def test_decrypt_unknown_id_returns_none(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    # both stores are empty; an unknown id must return None, not crash
+    assert storage.decrypt("any-key", "no-such-id", sd_card=False) is None
+    assert storage.decrypt("any-key", "no-such-id", sd_card=True) is None
+
+
+def test_decrypt_non_dict_storage_returns_none(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    # valid JSON that is not an object -> storage starts empty
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="[1, 2, 3]")):
+        storage = MnemonicStorage()
+    assert storage.stored == {}
+    assert storage.decrypt("any-key", "any-id", sd_card=False) is None

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -612,3 +612,186 @@ def test_customize_pbkdf2_iterations_create_and_decode(m5stickv):
     plaintext = decryptor.decrypt(cpl, version)
     words = bip39.mnemonic_from_bytes(plaintext)
     assert words == TEST_WORDS
+
+
+# ---------------------------------------------------------------------------
+# Mnemonic-storage file-load error handling.
+#
+# The four read/load fallbacks below catch only the file/JSON errors they
+# expect (OSError, ValueError), matching the OSError convention already used in
+# sd_card.py. The behaviour for a missing/unreadable file or malformed JSON is
+# unchanged ("storage starts empty" / "first store still writes"); the change
+# is that an *unexpected* error is no longer silently swallowed -- it now
+# propagates, so real bugs stop hiding. Each "propagates_unexpected_error" test
+# is the one that fails on the old bare-except code.
+# ---------------------------------------------------------------------------
+
+
+# --- __init__ SD load (self.stored_sd) ---
+
+
+def test_init_sd_load_propagates_unexpected_error(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=RuntimeError("unexpected"))
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        with pytest.raises(RuntimeError):
+            MnemonicStorage()
+
+
+def test_init_sd_load_oserror_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError("no card"))
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    assert storage.stored_sd == {}
+
+
+def test_init_sd_load_malformed_json_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    sd = mocker.MagicMock()
+    sd.read.return_value = "not valid json {{{"
+    sdhandler = mocker.MagicMock()
+    sdhandler.return_value.__enter__.return_value = sd
+    mocker.patch("krux.encryption.SDHandler", new=sdhandler)
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    assert storage.stored_sd == {}
+
+
+# --- __init__ flash load (self.stored) ---
+
+
+def test_init_flash_load_propagates_unexpected_error(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    # SD load fails with an expected error so only the flash load can raise.
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    mocker.patch("krux.encryption.open", side_effect=RuntimeError("unexpected"))
+    with pytest.raises(RuntimeError):
+        MnemonicStorage()
+
+
+def test_init_flash_load_oserror_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    mocker.patch("krux.encryption.open", side_effect=OSError("missing"))
+    storage = MnemonicStorage()
+    assert storage.stored == {}
+
+
+def test_init_flash_load_malformed_json_starts_empty(m5stickv, mocker):
+    from krux.encryption import MnemonicStorage
+
+    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
+    with patch(
+        "krux.encryption.open", new=mocker.mock_open(read_data="not valid json {{{")
+    ):
+        storage = MnemonicStorage()
+    assert storage.stored == {}
+
+
+# --- store_encrypted_kef SD read-before-write ---
+
+
+def test_store_sd_read_propagates_unexpected_error(
+    m5stickv, mocker, mock_file_operations
+):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    mocker.patch("krux.sd_card.SDHandler.read", side_effect=RuntimeError("unexpected"))
+    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")):
+        with pytest.raises(RuntimeError):
+            storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=True)
+
+
+def test_store_sd_read_oserror_still_writes(m5stickv, mocker, mock_file_operations):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    mocker.patch("krux.sd_card.SDHandler.read", side_effect=OSError("missing"))
+    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
+        success = storage.store_encrypted_kef(
+            "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
+        )
+    assert success is True
+    m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+def test_store_sd_read_malformed_json_still_writes(
+    m5stickv, mocker, mock_file_operations
+):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    mocker.patch("krux.sd_card.SDHandler.read", return_value="not valid json {{{")
+    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
+        success = storage.store_encrypted_kef(
+            "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
+        )
+    assert success is True
+    m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+# --- store_encrypted_kef flash read-before-write ---
+
+
+def test_store_flash_read_propagates_unexpected_error(m5stickv, mocker):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    write_handle = mocker.mock_open()
+    mocker.patch(
+        "krux.encryption.open",
+        side_effect=[RuntimeError("unexpected"), write_handle.return_value],
+    )
+    with pytest.raises(RuntimeError):
+        storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+
+
+def test_store_flash_read_oserror_still_writes(m5stickv, mocker):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    write_handle = mocker.mock_open()
+    mocker.patch(
+        "krux.encryption.open",
+        side_effect=[OSError("missing"), write_handle.return_value],
+    )
+    success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+    assert success is True
+    write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
+
+
+def test_store_flash_read_malformed_json_still_writes(m5stickv, mocker):
+    from krux.krux_settings import Settings
+    from krux.encryption import MnemonicStorage
+
+    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
+        storage = MnemonicStorage()
+    Settings().encryption.version = "AES-ECB"
+    read_handle = mocker.mock_open(read_data="not valid json {{{")
+    write_handle = mocker.mock_open()
+    mocker.patch(
+        "krux.encryption.open",
+        side_effect=[read_handle.return_value, write_handle.return_value],
+    )
+    success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
+    assert success is True
+    write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -661,19 +661,6 @@ def test_init_sd_load_malformed_json_starts_empty(m5stickv, mocker):
     assert storage.stored_sd == {}
 
 
-def test_init_sd_load_non_dict_json_starts_empty(m5stickv, mocker):
-    from krux.encryption import MnemonicStorage
-
-    sd = mocker.MagicMock()
-    sd.read.return_value = "[1, 2, 3]"
-    sdhandler = mocker.MagicMock()
-    sdhandler.return_value.__enter__.return_value = sd
-    mocker.patch("krux.encryption.SDHandler", new=sdhandler)
-    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
-        storage = MnemonicStorage()
-    assert storage.stored_sd == {}
-
-
 # --- __init__ flash load (self.stored) ---
 
 
@@ -705,16 +692,6 @@ def test_init_flash_load_malformed_json_starts_empty(m5stickv, mocker):
     ):
         storage = MnemonicStorage()
     assert storage.stored == {}
-
-
-def test_init_flash_load_non_dict_json_starts_empty(m5stickv, mocker):
-    from krux.encryption import MnemonicStorage
-
-    mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
-    with patch("krux.encryption.open", new=mocker.mock_open(read_data="[1, 2, 3]")):
-        storage = MnemonicStorage()
-    assert storage.stored == {}
-    assert storage.list_mnemonics() == []
 
 
 # --- store_encrypted_kef SD read-before-write ---
@@ -758,23 +735,6 @@ def test_store_sd_read_malformed_json_still_writes(
     storage = MnemonicStorage()
     Settings().encryption.version = "AES-ECB"
     mocker.patch("krux.sd_card.SDHandler.read", return_value="not valid json {{{")
-    with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
-        success = storage.store_encrypted_kef(
-            "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
-        )
-    assert success is True
-    m().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
-
-
-def test_store_sd_read_non_dict_json_still_writes(
-    m5stickv, mocker, mock_file_operations
-):
-    from krux.krux_settings import Settings
-    from krux.encryption import MnemonicStorage
-
-    storage = MnemonicStorage()
-    Settings().encryption.version = "AES-ECB"
-    mocker.patch("krux.sd_card.SDHandler.read", return_value="[1, 2, 3]")
     with patch("krux.sd_card.open", new=mocker.mock_open(read_data="{}")) as m:
         success = storage.store_encrypted_kef(
             "KEFecbID", KEF_ENVELOPE_ECB, sd_card=True
@@ -837,24 +797,6 @@ def test_store_flash_read_malformed_json_still_writes(m5stickv, mocker):
     write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
 
 
-def test_store_flash_read_non_dict_json_still_writes(m5stickv, mocker):
-    from krux.krux_settings import Settings
-    from krux.encryption import MnemonicStorage
-
-    with patch("krux.encryption.open", new=mocker.mock_open(read_data="{}")):
-        storage = MnemonicStorage()
-    Settings().encryption.version = "AES-ECB"
-    read_handle = mocker.mock_open(read_data="[1, 2, 3]")
-    write_handle = mocker.mock_open()
-    mocker.patch(
-        "krux.encryption.open",
-        side_effect=[read_handle.return_value, write_handle.return_value],
-    )
-    success = storage.store_encrypted_kef("KEFecbID", KEF_ENVELOPE_ECB, sd_card=False)
-    assert success is True
-    write_handle().write.assert_called_once_with(KEF_ECBENTROPY_ONLY_JSON)
-
-
 # ---------------------------------------------------------------------------
 # decrypt() must not crash on a missing id or non-dict storage.
 #
@@ -878,8 +820,8 @@ def test_decrypt_non_dict_storage_returns_none(m5stickv, mocker):
     from krux.encryption import MnemonicStorage
 
     mocker.patch("krux.encryption.SDHandler", side_effect=OSError)
-    # valid JSON that is not an object -> storage starts empty
+    # valid JSON that is not an object -> loaded as-is; decrypt must not crash
     with patch("krux.encryption.open", new=mocker.mock_open(read_data="[1, 2, 3]")):
         storage = MnemonicStorage()
-    assert storage.stored == {}
+    assert storage.stored == [1, 2, 3]
     assert storage.decrypt("any-key", "any-id", sd_card=False) is None


### PR DESCRIPTION
### What is this PR for?

Hardens encrypted mnemonic storage so missing IDs, malformed `seeds.json`, or unexpected non-object storage data do not crash encrypted mnemonic load/store/decrypt flows.

Changed:
- Missing encrypted mnemonic IDs now return `None` instead of raising.
- Malformed storage files are treated as empty storage and can be repaired on write.
- Valid but unexpected non-object `seeds.json` data is treated as empty storage.
- Storage file reads now catch only expected file/JSON errors.

The behavior-changing cases have regression tests that fail on the old code.

### Changes made to:
- [x] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [x] Yes, with the tzt. Tested encrypted mnemonic store/load on flash and SD, wrong key failure, correct key recovery, duplicate ID refusal, and no crashes. `uv run poe pre-commit` passed, 1113 tests.

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other