### PR TITLE
fix: Bug. Proportional LCD display scaling for camera preview

### DIFF
--- a/simulator/kruxsim/mocks/lcd.py
+++ b/simulator/kruxsim/mocks/lcd.py
@@ -99,8 +99,13 @@ def zoom_out(img, factor=0.6):
 
 def display(img, oft=(0, 0), roi=None):
 
-    image_width = 240
-    image_height = 320
+    # Derive target dimensions from ROI (matches real device behavior)
+    if roi:
+        image_width = roi[2]
+        image_height = roi[3]
+    else:
+        image_width = width()
+        image_height = height()
 
     # Swap and adjust oft axis
     if portrait:
@@ -112,40 +117,36 @@ def display(img, oft=(0, 0), roi=None):
             frame = img.get_frame()
             if isinstance(frame, mock.MagicMock):
                 return # avoid exception when img still not ready
-            
-            # Fix aspect ration by cutting the image
-            if frame.shape[1] / frame.shape[0] > image_width / image_height:
-                frame = frame[
-                    :,
-                    int(
-                        (frame.shape[1] - frame.shape[0] * image_width / image_height)
-                        / 2
-                    ) : int(
-                        (frame.shape[1] + frame.shape[0] * image_width / image_height)
-                        / 2
-                    ),
-                ]
-            else:
-                frame = frame[
-                    int(
-                        (frame.shape[0] - frame.shape[1] * image_height / image_width)
-                        / 2
-                    ) : int(
-                        (frame.shape[0] + frame.shape[1] * image_height / image_width)
-                        / 2
-                    ),
-                    :,
-                ]
-            frame = cv2.resize(
-                frame,
-                (image_width, image_height),
-                interpolation=cv2.INTER_AREA,
-            )
-            # If roi width < 240, zoom out keeping canvas size
-            # Case for M5StickV
+            if frame is None:
+                return
+
+            # frame is numpy (h, w, c), camera gives landscape e.g. (240, 320, 3)
+            # image_width/image_height target aspect = roi w/h (e.g. 320/240 for Amigo)
+
+            # Crop to target aspect ratio (center crop)
+            target_ratio = image_width / image_height
+            src_ratio = frame.shape[1] / frame.shape[0]
+            if src_ratio > target_ratio:
+                # Source is wider: crop sides
+                new_w = int(frame.shape[0] * target_ratio)
+                offset = (frame.shape[1] - new_w) // 2
+                frame = frame[:, offset:offset + new_w]
+            elif src_ratio < target_ratio:
+                # Source is taller: crop top/bottom
+                new_h = int(frame.shape[1] / target_ratio)
+                offset = (frame.shape[0] - new_h) // 2
+                frame = frame[offset:offset + new_h, :]
+
+            # Resize to target dimensions (cv2 expects width, height)
+            frame = cv2.resize(frame, (image_width, image_height), interpolation=cv2.INTER_AREA)
+
+            # If roi width < 240, zoom out keeping canvas size (M5StickV)
             if roi and roi[2] < 240:
                 frame = zoom_out(frame, 0.6)
+
+            # Swap to pygame format (w, h, c)
             frame = frame.swapaxes(0, 1)
+
         except Exception as e:
             print(f"Error: {e}")
             return
@@ -153,7 +154,7 @@ def display(img, oft=(0, 0), roi=None):
         # Cut image according to region of interest
         if roi:
             x, y, w, h = roi
-            frame = frame[y : y + h, x : x + w]
+            frame = frame[x:x + w, y:y + h]
 
         # Create a surface for the frame
         frame_surface = pg.surfarray.make_surface(frame)

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -563,8 +563,7 @@ class Display:
         region_x, region_y, region_w, region_h = 8, 0, 304, 240
 
         if kboard.is_amigo:
-            offset_x = 40 if self.flipped_x_coordinates else 120
-            offset_y = 40
+            offset_x, offset_y = 0, 0
             region_x, region_y, region_w, region_h = 0, 0, 320, 240
         elif kboard.is_m5stickv:
             # Apply lens correction and update img reference

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -982,7 +982,7 @@ def test_render_image(mocker, multiple_devices):
         assert krux.display.lcd.display.call_args.kwargs["roi"] == (68, 52, 185, 135)
     elif board.config["type"] == "amigo":
         krux.display.lcd.display.assert_called_once_with(
-            img, oft=(40, 40), roi=(0, 0, 320, 240)
+            img, oft=(0, 0), roi=(0, 0, 320, 240)
         )
     elif board.config["type"] == "dock":
         krux.display.lcd.display.assert_called_once_with(
@@ -1011,7 +1011,7 @@ def test_render_image_with_title(mocker, multiple_devices):
         assert krux.display.lcd.display.call_args.kwargs["roi"] == (92, 52, 161, 135)
     elif board.config["type"] == "amigo":
         krux.display.lcd.display.assert_called_once_with(
-            img, oft=(40, 40), roi=(0, 0, 320, 240)
+            img, oft=(0, 0), roi=(0, 0, 320, 240)
         )
     elif board.config["type"] == "dock":
         krux.display.lcd.display.assert_called_once_with(
@@ -1044,7 +1044,7 @@ def test_render_image_with_double_subtitle(mocker, multiple_devices):
         assert krux.display.lcd.display.call_args.kwargs["roi"] == (92, 52, 161, 135)
     elif board.config["type"] == "amigo":
         krux.display.lcd.display.assert_called_once_with(
-            img, oft=(40, 40), roi=(0, 0, 320, 240)
+            img, oft=(0, 0), roi=(0, 0, 320, 240)
         )
     elif board.config["type"] == "dock":
         krux.display.lcd.display.assert_called_once_with(


### PR DESCRIPTION
## Problem

Camera preview on Maix Amigo used hardcoded offsets and non-proportional aspect ratio cropping, causing distorted or misaligned camera images. The `image_width`/`image_height` were fixed at 240×320 regardless of actual ROI dimensions.

## Fix

- **display.py:** Set Amigo `oft=(0,0)` so camera image starts at top-left; set `region=(0,0,320,240)` for full screen coverage
- **lcd.py:** Derive `image_width/height` from ROI instead of hardcoded values. Clean center-crop aspect ratio logic (no distortion). Fix ROI slice order (x,y not y,x). Add null frame check.

### Before → After

| | Before | After |
|--|--------|-------|
| Amigo offset | `(40, 40)` or `(120, 40)` | `(0, 0)` |
| Image size source | Hardcoded `240×320` | Derived from ROI |
| Aspect ratio crop | Complex double-branch logic | Clean center-crop |
| ROI slice order | Incorrect `(y,x)` | Correct `(x,y)` |

## Files

| File | Lines |
|------|-------|
| `src/krux/display.py` | +1/-2 |
| `simulator/kruxsim/mocks/lcd.py` | +36/-36 |

## Testing

- ⚠️ **Tested on simulator only** — no hardware testing yet
- Simulator uses same Amigo configuration and cv2 center-crop logic