### PR TITLE
fix(uv): add src to poe task PYTHONPATH

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ urtypes = { path = "vendor/urtypes", editable = true }
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 
+[tool.poe.env]
+PYTHONPATH = "${POE_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
 [tool.poe.tasks]
 # format tasks
 format-src = "black src"


### PR DESCRIPTION
### What is this PR for?
Ensure poe-launched commands can import the local krux package under uv, where the project itself is not installed as a package.


### Changes made to:
- [x] Infrastructure
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- No, simulator only

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [X] Other
