### PR TITLE
feat: add home settings shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Switch from the pure-Python urtypes and foundation-ur-py packages to the new uUR
 - Replace custom quirc (library to decode QR codes from images) with k_quirc
 - Fix default theme contrast failures for Light, CypherPink, network
   indicators, and Amigo info panels
+- Add Home Settings shortcut for Printer and Encryption
 
 # Changelog 26.04.0 - April 2025
 

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -59,6 +59,7 @@ class Home(Page):
                     (t("Wallet"), self.wallet),
                     (t("Address"), self.addresses_menu),
                     (t("Sign"), self.sign),
+                    (t("Settings"), self.settings),
                     (shtn_reboot_label, self.shutdown),
                 ],
                 back_label=None,
@@ -212,6 +213,29 @@ class Home(Page):
                 ("PSBT", self.sign_psbt),
                 (t("Message"), self.sign_message),
             ],
+        )
+        submenu.run_loop()
+        return MENU_CONTINUE
+
+    def settings(self):
+        """Handler for the Home-screen settings shortcut"""
+        from ..settings_page import SettingsPage
+        from ...krux_settings import EncryptionSettings, PrinterSettings
+
+        settings_page = SettingsPage(self.ctx)
+        submenu = Menu(
+            self.ctx,
+            [
+                (
+                    t("Printer"),
+                    settings_page.namespace(PrinterSettings()),
+                ),
+                (
+                    t("Encryption"),
+                    settings_page.namespace(EncryptionSettings()),
+                ),
+            ],
+            back_status=settings_page.settings_exit_check,
         )
         submenu.run_loop()
         return MENU_CONTINUE

--- a/src/krux/pages/settings_page.py
+++ b/src/krux/pages/settings_page.py
@@ -247,6 +247,10 @@ class SettingsPage(Page):
 
         return MENU_EXIT
 
+    def settings_exit_check(self):
+        """Handler for leaving settings from a shortcut"""
+        return self._settings_exit_check()
+
     def namespace(self, settings_namespace):
         """Handler for navigating a particular settings namespace"""
 

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -266,6 +266,52 @@ def tdata(mocker):
     )
 
 
+def test_home_has_settings_before_shutdown(mocker, amigo):
+    from krux.pages.home_pages.home import Home
+
+    ctx = create_ctx(mocker, [])
+    home = Home(ctx)
+
+    labels = [item[0] for item in home.menu.menu]
+
+    assert labels[-2] == "Settings"
+    assert labels[-1] in ("Shutdown", "Reboot")
+
+
+def test_home_settings_shortcut_uses_printer_and_encryption_namespaces(mocker, amigo):
+    from krux.krux_settings import EncryptionSettings, PrinterSettings
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.home_pages.home import Home
+    from krux.pages.settings_page import SettingsPage
+
+    ctx = create_ctx(mocker, [])
+    home = Home(ctx)
+    handlers = []
+    settings_exit_check = mocker.patch.object(
+        SettingsPage, "_settings_exit_check", return_value=MENU_CONTINUE
+    )
+
+    def namespace(_settings_page, settings_namespace):
+        handlers.append(settings_namespace)
+        return lambda: MENU_CONTINUE
+
+    mocker.patch.object(SettingsPage, "namespace", namespace)
+
+    def run_loop():
+        shortcut_menu.call_args.kwargs["back_status"]()
+        return (0, MENU_CONTINUE)
+
+    shortcut_menu = mocker.patch("krux.pages.home_pages.home.Menu")
+    shortcut_menu.return_value.run_loop.side_effect = run_loop
+
+    assert home.settings() == MENU_CONTINUE
+    assert [namespace.__class__ for namespace in handlers] == [
+        PrinterSettings,
+        EncryptionSettings,
+    ]
+    settings_exit_check.assert_called_once()
+
+
 def test_load_mnemonic_view(mocker, amigo):
     from krux.pages.home_pages.home import Home
     from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV


### PR DESCRIPTION
### What is this PR for?

Add a Home-screen Settings shortcut for the two options requested in #790:
Printer and Encryption.

This keeps the shortcut narrow. It does not expose the full Settings tree from
Home, just the options users may need before loading a wallet or restarting the
device.

### Changes made to:

- [ ] Infrastructure
- [x] Code
- [x] Tests
- [ ] Docs
- [x] CHANGELOG

### Did you build the code and tested on device?

- [x] Yes, built and tested on TZT

Home screen now includes Settings before Reboot.
<img width="2048" height="2143" alt="IMG_7896" src="https://github.com/user-attachments/assets/89b59156-9e04-41d2-b453-97fa7e18ec83" />
Home > Settings shortcut opens only Printer and Encryption.
<img width="1766" height="2515" alt="IMG_7897" src="https://github.com/user-attachments/assets/71e9b212-8fdb-4517-800b-fad95950a779" />


### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other

Closes #790.

### Tested with:

- `poetry run poe lint`
- `poetry run pytest tests/pages/home_pages/test_home.py -q`
- `poetry run black --check src/krux/pages/home_pages/home.py src/krux/pages/settings_page.py tests/pages/home_pages/test_home.py`
- `git diff --check upstream/develop..HEAD`
