### PR TITLE
chore: `.gitignore` hygiene update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,9 @@ krux-*/ktool*
 .codex/
 .claude/
 .cursorrules
-AGENT.md
+AGENTS.md
 CLAUDE.md
+GEMINI.md
+.github/copilot-instructions.md
+.github/agents/
+.github/instructions/


### PR DESCRIPTION
### What is this PR for?
This PR is a `.gitignore` hygiene update. It renames `AGENT.md` to `AGENTS.md` (a typo), adds entries for `GEMINI.md` tooling files and `.github/agents/`, `.github/instructions/` and
`.github/copilot-instructions` as intentional.

Fix #906.

### Changes made to:
- [ ] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG]
- [x] Other: `.gitignore`


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other: `.gitignore` hygiene.