### PR TITLE
fix(test): add throttle to fake camera in test_fill_flash

### DIFF
--- a/tests/pages/test_fill_flash.py
+++ b/tests/pages/test_fill_flash.py
@@ -1,3 +1,4 @@
+import time
 import pytest
 from . import create_ctx
 
@@ -123,8 +124,6 @@ def test_fill_flash_entropy_timeout_scenario(amigo, mocker):
 
 
 def test_fill_flash_insufficient_entropy_scenario(amigo, mocker):
-    # Test insufficient entropy scenario using mocker.patch instead of PropertyMock
-    # Following @qlrd recommendation to avoid false positive assertions
     from krux.pages.fill_flash import FillFlash
     from krux.pages.capture_entropy import CameraEntropy, INSUFFICIENT_VARIANCE_TH
     from krux.input import BUTTON_ENTER, BUTTON_PAGE, BUTTON_PAGE_PREV
@@ -137,10 +136,22 @@ def test_fill_flash_insufficient_entropy_scenario(amigo, mocker):
 
     ctx = create_ctx(mocker, btn_sequence)
     fill_flash = FillFlash(ctx)
+
+    # throttle the fake camera so the 25s timeout elapse
+    img = mocker.MagicMock()
+
+    def _throttle():
+        # setup the mocked camera like a real one, or the timeout loop
+        # spins more than necessary
+        time.sleep(0.05)
+        return img
+
+    mocker.patch("sensor.snapshot", side_effect=_throttle)
+
     entropy_measurement = CameraEntropy(ctx)
 
-    # Use mocker.patch.object instead of PropertyMock as per @qlrd recommendation
-    # This avoids false positive assertions that can occur with PropertyMock
+    # Test insufficient entropy scenario using mocker.patch
+    # to avoid false positive assertions
     mocker.patch.object(
         entropy_measurement,
         "rms_value",


### PR DESCRIPTION
### What is this PR for?
This commit add a 0.05s sleep to the mocked snapshot of `test_fill_flash_insufficient_entropy_scenario` to keeps the timeout real (test still takes ~25s and raises as expected) but cuts iterations from ~500k (a lot of garbage accumulated throug mocks) to nearly 500 in local tests , so the garbage never exists, going from ~30s to ~25s.

Fix #905.


### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: `tests/` hygiene
