### PR TITLE
Speed up the test suite and exercise the real secp256k1

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: webiny/action-conventional-commits@v1.3.0
         with:
-          allowed-commit-types: "feat,fix,docs,style,refactor,test,i18n,ci,chore,git"
+          allowed-commit-types: "feat,fix,docs,style,refactor,perf,test,i18n,ci,chore,git"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,10 @@ jobs:
         run: uv python install ${{ matrix.py-version }}
       - name: Sync dependencies
         run: uv sync --frozen --python ${{ matrix.py-version }}
+      - name: Build libsecp256k1
+        run: uv run --python ${{ matrix.py-version }} poe secp256k1-build
+      - name: Check embit uses the C secp256k1
+        run: uv run --python ${{ matrix.py-version }} poe secp256k1-check
       - name: Run tests
         run: uv run --python ${{ matrix.py-version }} poe test-simple
 
@@ -124,6 +128,10 @@ jobs:
         run: uv python install 3.12.13
       - name: Sync dependencies
         run: uv sync --frozen --python 3.12.13
+      - name: Build libsecp256k1
+        run: uv run --python 3.12.13 poe secp256k1-build
+      - name: Check embit uses the C secp256k1
+        run: uv run --python 3.12.13 poe secp256k1-check
       - name: Build coverage file
         run: uv run --python 3.12.13 pytest --cache-clear --cov src/krux --cov-report xml tests
       - name: Upload coverage reports to Codecov with GitHub Action

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ uv run poe lint
 uv run poe test
 ```
 
+Before the first run, build the `libsecp256k1` that the `embit` submodule pins (needs `gcc` and `make`):
+```bash
+uv run poe secp256k1-build
+```
+
+Without it `embit` falls back to its pure Python EC implementation, which is slower and does not always match the C library the firmware runs, so some signature paths get exercised differently than on device. CI builds it and fails if the fallback is in use. To check your own setup:
+```bash
+uv run poe secp256k1-check
+```
+
 Note: The coverage report will be created at the `htmlcov` folder `file:///path/to/krux/htmlcov/index.html`. 
 
 For more verbose output (e.g., to see the output of print statements):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,25 @@ vulture.ref = "vulture-src vulture_whitelist.py"
 vulture-make = { shell = "vulture src --make-whitelist > vulture_whitelist.py" }
 vulture-whitelist.ref = "vulture-make"
 
+# secp256k1 tasks
+# Builds the libsecp256k1-zkp pinned by the embit submodule and drops it where
+# embit's ctypes backend looks for it. Without it embit falls back to its pure
+# Python EC implementation, which is slower and does not always behave like the
+# C library the firmware runs.
+secp256k1-build = { shell = """
+make -C vendor/embit/secp256k1
+mkdir -p vendor/embit/src/embit/util/prebuilt
+cp vendor/embit/secp256k1/build/libsecp256k1_* vendor/embit/src/embit/util/prebuilt/
+""" }
+secp256k1-check = { shell = '''python -c "
+import sys
+from embit.util import secp256k1
+
+using_c = hasattr(secp256k1, '_secp')
+print('embit secp256k1 backend:', 'C library' if using_c else 'pure Python')
+sys.exit(0 if using_c else 1)
+"''' }
+
 # test tasks
 test-clean = """python -c 'import shutil, os; os.path.exists("htmlcov") and shutil.rmtree("htmlcov")'"""
 test-cov = "pytest --cache-clear --cov src/krux --cov-report html ./tests --cov-context=test --cov-report term-missing"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,18 @@ def reset_krux_modules():
             del sys.modules[name]
 
 
+@pytest.fixture(autouse=True)
+def no_gc_collect(monkeypatch):
+    """Krux calls gc.collect() often to manage the device's small heap.
+    On CPython each call walks the much bigger test heap (mostly mock objects)
+    and does nothing useful, costing about a third of the suite runtime.
+    Tests that assert on gc.collect patch it themselves, over this one.
+    """
+    import gc
+
+    monkeypatch.setattr(gc, "collect", lambda *args: 0)
+
+
 @pytest.fixture
 def mp_modules(mocker, monkeypatch):
     from embit.util import secp256k1

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "embit"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "vendor/embit" }
 
 [package.metadata]


### PR DESCRIPTION
### What is this PR for?
Test infrastructure only, no src/krux changes. Full suite: 151s to 85s (1121 tests).

Stub gc.collect() in tests. Krux calls it to manage the device's small heap; under CPython it just walks the big mock-object test heap. Profiling put 35.3s across 2821 calls there. Autouse fixture in conftest.py; test_camera.py patches it itself and still passes. 151s to 118s, coverage byte-identical.

Build the C libsecp256k1 that embit pins. vendor/embit already ships secp256k1-zkp plus a Makefile, but nothing built it, so tests ran embit's pure Python EC. That backend also behaves differently: firmware.bin.bad.sig raises while parsing, where libsecp256k1 parses it and fails verification like the device does. So test_upgrade_fails_when_sig_is_bad was passing via the blanket except: and the real "Bad signature" branch never ran in CI. Now it does: firmware.py 99% to 100%. Adds poe secp256k1-build / poe secp256k1-check, both wired into CI so a failed build fails loudly instead of falling back silently. 118.2s to 84.6s.

Also fixes pre-existing uv.lock drift (embit 0.8.0 vs the vendored 0.8.1), folded into the first commit by a rebase.

Verify

uv run poe secp256k1-build
uv run poe secp256k1-check   # prints "C library"
uv run poe tests             # 1121 passed

Contributors need gcc and make for the one-time build; without it the suite still passes, just slower. 

### Changes made to:
- [ ] Code
- [x] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other
