### PR TITLE
fix: prevent black screen on WonderMV

### DIFF
--- a/simulator/kruxsim/mocks/sensor.py
+++ b/simulator/kruxsim/mocks/sensor.py
@@ -76,7 +76,7 @@ class Mockqrcode:
 capturer = None
 
 
-def reset(freq=None, dual_buff=False):
+def reset(freq=None, dual_buff=False, choice=None):
     pass
 
 

--- a/src/krux/camera.py
+++ b/src/krux/camera.py
@@ -81,6 +81,15 @@ class Camera:
             sensor.run(0)
         except Exception as e:
             print("Camera not found:", e)
+        if kboard.is_wonder_mv:
+            # Camera power-on inrush may brownout-reset the LCD controller,
+            # leaving a black screen while firmware keeps running.
+            # Re-initialize the LCD and redraw the splash to recover.
+            from .display import display, SPLASH
+
+            display.initialize_lcd()
+            display.clear()
+            display.draw_centered_text(SPLASH)
 
     def _rotate_yaboom_or_wondermv(self):
         return (
@@ -92,7 +101,14 @@ class Camera:
 
     def initialize_sensor(self, mode=QR_SCAN_MODE):
         """Initializes the camera"""
-        sensor.reset(freq=18200000)
+        if kboard.is_wonder_mv:
+            # GC2145 sensor: probe only GC types (choice=2), skipping OV probe
+            # rounds and their camera power cycles (inrush).
+            # TODO: yahboom and wonder_k also ship GC2145 and could benefit,
+            # but only wonder_mv was tested so far.
+            sensor.reset(freq=18200000, choice=2)
+        else:
+            sensor.reset(freq=18200000)
         self.cam_id = sensor.get_id()
         if (
             kboard.is_cube

--- a/src/krux/camera.py
+++ b/src/krux/camera.py
@@ -104,6 +104,7 @@ class Camera:
         if kboard.is_wonder_mv:
             # GC2145 sensor: probe only GC types (choice=2), skipping OV probe
             # rounds and their camera power cycles (inrush).
+            # See: sensor_reset() in MaixPy/components/micropython/port/src/omv/sensor.c
             # TODO: yahboom and wonder_k also ship GC2145 and could benefit,
             # but only wonder_mv was tested so far.
             sensor.reset(freq=18200000, choice=2)

--- a/src/krux/display.py
+++ b/src/krux/display.py
@@ -178,6 +178,9 @@ class Display:
             lcd.init(invert=False)
             lcd.mirror(False)
             lcd.bgr_to_rgb(False)
+        # lcd.init resets the driver's rotation state, so invalidate the
+        # cached orientation to make to_portrait() re-apply it on re-init
+        self.portrait = False
         self.to_portrait()
 
     def gpio_backlight_ctrl(self, brightness):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,8 @@ def mp_modules(mocker, monkeypatch):
     monkeypatch.setitem(sys.modules, "sensor", mocker.MagicMock())
     lcd_mock = mocker.MagicMock()
     lcd_mock.string_width_px.side_effect = lambda s: len(s) * 8  # Assume 8px per char
+    lcd_mock.width.return_value = 240
+    lcd_mock.height.return_value = 320
     monkeypatch.setitem(sys.modules, "lcd", lcd_mock)
     monkeypatch.setitem(sys.modules, "Maix", mocker.MagicMock())
     monkeypatch.setitem(sys.modules, "fpioa_manager", mocker.MagicMock())


### PR DESCRIPTION
### What is this PR for?

Fixes black screen on WonderMV boot caused by LCD controller brownout when the camera powers on. Firmware keeps running, but the panel stays blank until LCD is re-initialized.

### Changes made to:
- [x] Code
- [ ] Tests
- [ ] Docs
- [ ] CHANGELOG

### Did you build the code and tested on device?
- [x] Yes, build and tested on WonderMV

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other

### Details
- Re-init LCD and redraw splash after camera init on WonderMV (recovers from brownout)
- Use `sensor.reset(..., choice=2)` on WonderMV to probe only GC sensors (GC2145), skipping OV probe power cycles
- Reset `self.portrait` before `to_portrait()` so re-init applies rotation correctly after `lcd.init`
- Update simulator `sensor.reset` mock to accept `choice`