### PR TITLE
Feat/bip322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Switch from the pure-Python urtypes and foundation-ur-py packages to the new uUR
   reading a setting no longer writes back to storage
 - Hide the QR code title in line and region view modes, where it overlapped
   the part index
+- Check for recids in BIP-137 message signing
 
 # Changelog 26.04.0 - April 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Switch from the pure-Python urtypes and foundation-ur-py packages to the new uUR
 - Hide the QR code title in line and region view modes, where it overlapped
   the part index
 - Check for recids in BIP-137 message signing
+- Add BIP-322 simple message signing for P2WPKH and P2TR single-sig
+  wallets, with BIP-137 fallback for P2PKH and P2SH-P2WPKH
 
 # Changelog 26.04.0 - April 2026
 

--- a/src/krux/bip137.py
+++ b/src/krux/bip137.py
@@ -1,0 +1,77 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2021-2026 Krux contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+P2PKH_UNCOMPRESSED_HEADER = 27
+P2PKH_HEADER = 31
+P2SH_P2WPKH_HEADER = 35
+P2WPKH_HEADER = 39
+MESSAGE_MAGIC = b"\x18Bitcoin Signed Message:\n"
+RECID_OFFSET = P2PKH_HEADER - P2PKH_UNCOMPRESSED_HEADER
+
+
+def message_commitment(message):
+    """Double-SHA256 commitment over the BIP-137 magic"""
+    from embit import compact
+
+    try:
+        import uhashlib as hashlib
+    except ImportError:
+        import hashlib
+
+    # BIP137 commitment message:
+    # `SHA256(SHA256(MAGIC // varint // message))`
+    varint = compact.to_bytes(len(message))
+    _message = MESSAGE_MAGIC + varint + message
+    return hashlib.sha256(hashlib.sha256(_message).digest()).digest()
+
+
+def build_header(raw_sig, script_type, compressed=True):
+    """Build header byte from raw signature and script_type"""
+    # Avoid some unexpected header
+    rsig = raw_sig[0]
+    if not P2PKH_UNCOMPRESSED_HEADER <= rsig <= P2PKH_HEADER + 3:
+        raise ValueError("Invalid sig header: %d" % rsig)
+
+    # grab the 2 least significant bits as recId
+    # and normalize with a minimum p2pkh (uncompressed) flag
+    recid = (raw_sig[0] - P2PKH_UNCOMPRESSED_HEADER) & 3
+
+    if script_type == "p2sh-p2wpkh":
+        return P2SH_P2WPKH_HEADER + recid
+    if script_type == "p2wpkh":
+        return P2WPKH_HEADER + recid
+
+    # compressed=False is only meaningful for p2pkh
+    return (
+        P2PKH_UNCOMPRESSED_HEADER
+        + recid
+        + (0 if not compressed and script_type == "p2pkh" else RECID_OFFSET)
+    )
+
+
+def sign(message, key, derivation, script_type="p2pkh", compressed=True):
+    """Sign a BIP137 `message` with `key` at `derivation` for some `script_type`"""
+    commitment = message_commitment(message)
+    raw_sig = key.sign_at(derivation, commitment)
+    header = build_header(raw_sig, script_type, compressed)
+    sig = bytes([header]) + raw_sig[1:]
+    return (commitment, sig)

--- a/src/krux/bip322.py
+++ b/src/krux/bip322.py
@@ -1,0 +1,260 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2021-2026 Krux contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = b"\x09"
+OP_RETURN = b"\x6a"
+
+
+def build_bip322_txs(message, spk):
+    """BIP-322 to_spend and to_sign txs per spec"""
+    # keep version=0 and sequence=0 — embit's `or`-fallbacks at
+    # psbt.py:200/:667 substitute defaults.
+    from embit import hashes
+    from embit.script import Script
+    from embit.transaction import (
+        Transaction,
+        TransactionInput,
+        TransactionOutput,
+    )
+
+    msg_hash = hashes.tagged_hash("BIP0322-signed-message", message)
+    to_spend = Transaction(
+        version=0,
+        vin=[
+            TransactionInput(
+                txid=b"\x00" * 32,
+                vout=0xFFFFFFFF,
+                script_sig=Script(b"\x00\x20" + msg_hash),
+                sequence=0,
+            )
+        ],
+        vout=[TransactionOutput(value=0, script_pubkey=spk)],
+        locktime=0,
+    )
+    to_sign = Transaction(
+        version=0,
+        vin=[
+            TransactionInput(
+                txid=to_spend.txid(),
+                vout=0,
+                script_sig=Script(b""),
+                sequence=0,
+            )
+        ],
+        vout=[TransactionOutput(value=0, script_pubkey=Script(OP_RETURN))],
+        locktime=0,
+    )
+    return to_spend, to_sign
+
+
+def check_bip322_psbt(psbt):
+    """Detect BIP-322 PSBT fake tx"""
+    if PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE not in psbt.unknown:
+        return False
+    message = psbt.unknown[PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE]
+
+    tx = psbt.tx
+    if len(tx.vin) != 1 or len(tx.vout) != 1:
+        return False
+    if tx.vin[0].vout != 0:
+        return False
+    if tx.vout[0].value != 0:
+        return False
+    if tx.vout[0].script_pubkey.data != OP_RETURN:
+        return False
+
+    # prevout scriptpubkey from witness or legacy utxo (embit/psbt.py L214);
+    spk = psbt.inputs[0].script_pubkey
+    if spk is None:
+        return False
+
+    to_spend, _ = build_bip322_txs(message, spk)
+    return tx.vin[0].txid == to_spend.txid()
+
+
+def sign(psbt, key):
+    """Sign and finalize a BIP-322 `smp` PSBT"""
+    if not check_bip322_psbt(psbt):
+        raise ValueError("Not a BIP-322 PSBT")
+
+    from embit import script
+    from embit.script import Witness
+    from embit.transaction import SIGHASH
+
+    message = psbt.unknown[PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE]
+    inp = psbt.inputs[0]
+    spk = inp.script_pubkey
+    script_type = spk.script_type()
+
+    if script_type == "p2sh":
+        # Sparrow resolves P2SH_P2WPKH via PSBTInput.getScriptType()
+        # when redeem is P2WPKH (drongo psbt/PSBTInput.java ~L1041)
+        script_type = "p2sh-p2wpkh"
+
+    _, to_sign = build_bip322_txs(message, spk)
+
+    fingerprint = key.root.my_fingerprint
+    derivations = (
+        inp.taproot_bip32_derivations
+        if script_type == "p2tr"
+        else inp.bip32_derivations
+    )
+
+    # check for some wrong deriv path with same-fingerprint
+    pub = None
+    prv = None
+    for _pub, _deriv in derivations.items():
+        _built = None
+        _d = _deriv[1] if isinstance(_deriv, tuple) else _deriv
+        if _d.fingerprint == fingerprint:
+            _derived = key.root.derive(_d.derivation)
+            _derived_pub = _derived.get_public_key()
+            if script_type == "p2tr":
+                if _derived_pub.xonly() == _pub.xonly():
+                    _built = script.p2tr(_pub)
+
+            if _derived_pub == _pub:
+                if script_type == "p2pkh":
+                    _built = script.p2pkh(_pub)
+                if script_type == "p2wpkh":
+                    _built = script.p2wpkh(_pub)
+                if script_type == "p2sh-p2wpkh":
+                    _built = script.p2sh(script.p2wpkh(_pub))
+
+            if _built is not None and _built.data == spk.data:
+                pub = _pub
+                prv = _derived.key
+                break
+
+    if prv is None:
+        raise ValueError("Key not match PSBT")
+
+    # Sparrow uses BIP-137 for legacy and our sign_message_ui routes those
+    # PSBTs to bip137 (i.e., they even allow in UI). We kept the suggested
+    # impl from spec (maybe another watch-wallet could impl full spec)
+    if script_type == "p2pkh":
+        h = to_sign.sighash_legacy(
+            input_index=0,
+            script_pubkey=spk,
+            sighash=SIGHASH.ALL,
+        )
+        sig = prv.sign(h).serialize() + bytes([SIGHASH.ALL])
+        inp.partial_sigs[pub] = sig
+
+    if script_type in ("p2wpkh", "p2sh-p2wpkh"):
+        _script = script.p2pkh_from_p2wpkh(script.p2wpkh(pub))
+        h = to_sign.sighash_segwit(
+            input_index=0,
+            script_pubkey=_script,
+            value=0,
+            sighash=SIGHASH.ALL,
+        )
+        sig = prv.sign(h).serialize() + bytes([SIGHASH.ALL])
+        inp.partial_sigs[pub] = sig
+
+    if script_type == "p2tr":
+        h = to_sign.sighash_taproot(
+            input_index=0,
+            script_pubkeys=[spk],
+            values=[0],
+            sighash=SIGHASH.ALL,
+        )
+        sig = prv.taproot_tweak(b"").schnorr_sign(h).serialize() + bytes([SIGHASH.ALL])
+        inp.taproot_key_sig = sig
+        inp.final_scriptwitness = Witness([sig])
+
+    finalize_simple(psbt, pub)
+    return psbt
+
+
+def serialize_bip322(psbt):
+    """Serialize a BIP-322 fake PSBT"""
+    # embit's `or` fallback properties at psbt.py:667/:200 rewrite version
+    # and sequence during serialize, breaking Sparrow's
+    # `PSBTInput.verifySignatures`. We need first rewrite them back to zero
+    # in-place:
+    #
+    # - fail unless the bytes still match embit's defaults (refuse to zeroize version)
+    # - `smp` prefix PSBT is fixed (0x3D) -- one input, one output, OP_RETURN, ...
+    # - no need to check, until we need to update, with varint checks on bit
+    #   flag tx size (will never be >= 0xFD)
+    raw = psbt.serialize()
+    pos = 8
+
+    # Guard against (version=2)
+    ver = int.from_bytes(raw[pos : pos + 4], "little")
+    if ver != 2:
+        raise ValueError("PSBT mismatch version: %s" % ver)
+    raw = raw[:pos] + b"\x00\x00\x00\x00" + raw[pos + 4 :]
+
+    # Guards against silent corruption on (sequence=0xFFFFFFFF)
+    # if embit's PSBT shifts upstream
+    seq_pos = pos + 4 + 1 + 32 + 4 + 1
+    if raw[seq_pos : seq_pos + 4] != b"\xff\xff\xff\xff":
+        raise ValueError("PSBT mismatch seq: on 0xFFFFFFFF")
+
+    # Apply sequence=0x00000000
+    return raw[:seq_pos] + b"\x00\x00\x00\x00" + raw[seq_pos + 4 :]
+
+
+def finalize_simple(psbt, pub):
+    """finalize BIP-322 simple-form for the partial_sig matching `pub`"""
+    from embit import script
+    from embit.script import Script, Witness
+
+    inp = psbt.inputs[0]
+
+    # Taproot key-path signature is already populated
+    # in `inp.final_scriptwitness`. Nothing more to do.
+    if inp.final_scriptwitness is None:
+        if not inp.partial_sigs:
+            raise ValueError("PSBT no signatures")
+
+        # The caller has already matched `pub` to the wallet fingerprint via
+        # `bip32_derivations` in `sign()`. Other partial_sigs (e.g. from
+        # co-signers or stray entries) are ignored.
+        sig = inp.partial_sigs.get(pub)
+        if sig is None:
+            raise ValueError("Key not match")
+        spk = inp.script_pubkey.data
+
+        # P2WPKH: OP_0 PUSH20 <pkh>
+        if len(spk) == 22 and spk[:2] == b"\x00\x14":
+            inp.final_scriptwitness = Witness([sig, pub.sec()])
+
+        # P2SH-P2WPKH: OP_HASH160 PUSH20 <sh> OP_EQUAL.
+        elif len(spk) == 23 and spk[:2] == b"\xa9\x14" and spk[-1] == 0x87:
+            inp.final_scriptwitness = Witness([sig, pub.sec()])
+            redeem = script.p2wpkh(pub).data
+            inp.final_scriptsig = Script(bytes([len(redeem)]) + redeem)
+
+        # P2PKH: OP_DUP OP_HASH160 PUSH20 <pkh> OP_EQUALVERIFY OP_CHECKSIG.
+        elif len(spk) == 25 and spk[:3] == b"\x76\xa9\x14" and spk[-2:] == b"\x88\xac":
+            sec = pub.sec()
+            inp.final_scriptsig = Script(
+                bytes([len(sig)]) + sig + bytes([len(sec)]) + sec
+            )
+
+        else:
+            raise ValueError("Unsupported script")
+
+    return inp.final_scriptsig, inp.final_scriptwitness

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -36,11 +36,12 @@ from ...display import (
 )
 from ...baseconv import base_encode
 from ...krux_settings import t
-from ...qr import FORMAT_NONE
+from ...qr import FORMAT_NONE, FORMAT_BBQR, FORMAT_UR
 from ...sd_card import (
     SIGNATURE_FILE_EXTENSION,
     SIGNED_FILE_SUFFIX,
     PUBKEY_FILE_EXTENSION,
+    PSBT_FILE_EXTENSION,
 )
 from ...settings import TEST_TXT, MAIN_TXT
 from ...kboard import kboard
@@ -59,9 +60,15 @@ class SignMessage(Utils):
 
         if load_method == LOAD_FROM_CAMERA:
             from ..qr_capture import QRCodeCapture
+            from uUR import UR, Types
 
             qr_capture = QRCodeCapture(self.ctx)
             data, qr_format = qr_capture.qr_capture_loop()
+            if isinstance(data, UR):
+                try:
+                    data = Types.psbt_from_cbor(data.cbor)
+                except Exception:
+                    data = None
             return (data, qr_format, "")
         if load_method == LOAD_FROM_SD:
             message_filename, data = self.load_file(prompt=False)
@@ -138,7 +145,8 @@ class SignMessage(Utils):
 
         derivation = bip32.parse_path(derivation_str)
         self._display_message_sign_prompt(
-            message, self.fit_to_line(address, str(derivation[4]) + ". ", fixed_chars=3)
+            self._decode_and_replace_utf8_errors(message),
+            self.fit_to_line(address, str(derivation[4]) + ". ", fixed_chars=3),
         )
 
         if not self.prompt(t("Sign?"), BOTTOM_PROMPT_LINE):
@@ -163,7 +171,9 @@ class SignMessage(Utils):
         )
         offset_y += (
             self.ctx.display.draw_hcentered_text(
-                message.decode(), offset_y, max_lines=max_lines
+                self._decode_and_replace_utf8_errors(message),
+                offset_y,
+                max_lines=max_lines,
             )
             + 1
         ) * FONT_HEIGHT
@@ -283,6 +293,8 @@ class SignMessage(Utils):
         message_filename="",
         message="",
         address="",
+        sd_binary_extension="",
+        qr_payload=None,
     ):
         """Exports the message signature to a QR code or SD card"""
         submenu = Menu(
@@ -304,10 +316,22 @@ class SignMessage(Utils):
         pubkey = binascii.hexlify(self.ctx.wallet.key.account.sec()).decode()
 
         if index == 0:  # QR
-            at_address = address != ""
-            self._export_to_qr(sig, pubkey, qr_format, at_address)
+            if qr_payload is not None:
+                title = t("Signed Message")
+                self.display_qr_codes(qr_payload, qr_format, title)
+                self.print_standard_qr(qr_payload, qr_format, title)
+            else:
+                at_address = address != ""
+                self._export_to_qr(sig, pubkey, qr_format, at_address)
         elif self.has_sd_card():  # SD
-            self._export_to_sd(sig, pubkey, message_filename, message, address)
+            self._export_to_sd(
+                sig,
+                pubkey,
+                message_filename,
+                message,
+                address,
+                sd_binary_extension,
+            )
         return MENU_CONTINUE
 
     def _export_to_qr(self, sig, pubkey, qr_format, at_address=False):
@@ -332,11 +356,32 @@ class SignMessage(Utils):
         self.display_qr_codes(pubkey, qr_format, title)
         self.print_standard_qr(pubkey, qr_format, title)
 
-    def _export_to_sd(self, sig, pubkey, message_filename, message="", address=""):
+    def _export_to_sd(
+        self,
+        sig,
+        pubkey,
+        message_filename,
+        message="",
+        address="",
+        sd_binary_extension="",
+    ):
         """Exports the signature and public key to SD card"""
         from ..file_operations import SaveFile
 
         save_page = SaveFile(self.ctx)
+        if sd_binary_extension:
+            save_page.save_file(
+                sig,
+                "message",
+                message_filename,
+                t("Signature:"),
+                sd_binary_extension,
+                SIGNED_FILE_SUFFIX,
+                prompt=False,
+                save_as_binary=True,
+            )
+            return
+
         if address:
             file_content = ""
             file_content = SD_MESSAGE_HEADER + "\n"
@@ -356,6 +401,7 @@ class SignMessage(Utils):
             extension,
             SIGNED_FILE_SUFFIX,
             prompt=False,
+            save_as_binary=not bool(address),
         )
 
         if not address:
@@ -370,14 +416,147 @@ class SignMessage(Utils):
                 False,
             )
 
-    def sign_message(self):
-        """Sign message user interface"""
-        data, qr_format, message_filename = self._load_message()
+    def _try_parse_psbt(self, data):
+        """Best-effort parse of `data` as a PSBT; return parsed PSBT or None."""
+        from embit.psbt import PSBT
+        from embit.base import EmbitError
 
+        if not isinstance(data, (str, bytes, bytearray)):
+            return None
+
+        try:
+            if isinstance(data, str):
+                return PSBT.from_base64(data)
+            try:
+                return PSBT.parse(data)
+            except (EmbitError, ValueError):
+                try:
+                    return PSBT.from_base64(data.decode("ascii"))
+                except (UnicodeError, EmbitError, ValueError, TypeError):
+                    return None
+        except (EmbitError, ValueError, TypeError):
+            return None
+
+    def _decode_and_replace_utf8_errors(self, message):
+        if isinstance(message, (bytes, bytearray)):
+            return message.decode("utf-8", errors="replace")
+        return message
+
+    def _sign_bip322_message(self, data, qr_format=FORMAT_NONE, message_filename=""):
+        """
+        Given a parsed valid BIP322 psbt `data`, check for script types and
+        add proper derivations/fingerprints to sign
+        """
+        from krux import bip137, bip322
+
+        spk = data.inputs[0].script_pubkey
+        script_type = spk.script_type()
+
+        # Any P2SH wrapper is treated as p2sh-p2wpkh for smp singlesig; Sparrow
+        # disambiguates via PSBTInput.getScriptType() when redeem is visible
+        script_type = "p2sh-p2wpkh" if script_type == "p2sh" else script_type
+        message = data.unknown[bip322.PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE]
+        address = spk.address(network=self.ctx.wallet.key.network)
+
+        derivations = (
+            data.inputs[0].taproot_bip32_derivations
+            if script_type == "p2tr"
+            else data.inputs[0].bip32_derivations
+        )
+
+        self._display_message_sign_prompt(
+            self._decode_and_replace_utf8_errors(message), self.fit_to_line(address)
+        )
+        if not self.prompt(t("Sign?"), BOTTOM_PROMPT_LINE):
+            return MENU_CONTINUE
+
+        sd_binary_extension = ""
+        qr_payload = None
+
+        # BIP recommends sign legacy PSBT types fallbacking to bip137;
+        # Sparrow uses BIP-137 instead and will not sign 322 on >=2.5.x.
+        # The choice here is to follow BIP spec since they will not be allowed
+        # in sparrow 2.5.x anyway, but this works as backward compatible on
+        # sparrow <2.5.x and electrum
+        if script_type in ("p2pkh", "p2sh-p2wpkh"):
+            root = self.ctx.wallet.key.root
+            fingerprint = root.my_fingerprint
+            derivation_path = None
+            for _pub, d in derivations.items():
+                _d = d[1] if isinstance(d, tuple) else d
+                if (
+                    _d.fingerprint == fingerprint
+                    and root.derive(_d.derivation).get_public_key() == _pub
+                ):
+                    if script_type == "p2pkh":
+                        _built = script.p2pkh(_pub)
+                    else:
+                        _built = script.p2sh(script.p2wpkh(_pub))
+
+                    if _built.data == spk.data:
+                        derivation_path = _d
+                        break
+            if derivation_path is None:
+                self.flash_error(t("Failed to load"))
+                return MENU_CONTINUE
+            _, serialized = bip137.sign(
+                message,
+                self.ctx.wallet.key,
+                derivation_path.derivation,
+                script_type,
+            )
+        else:
+            try:
+                signed_psbt = bip322.sign(data, self.ctx.wallet.key)
+                serialized = bip322.serialize_bip322(signed_psbt)
+            except ValueError as exc:
+                self.flash_error(str(exc))
+                return MENU_CONTINUE
+
+            sd_binary_extension = PSBT_FILE_EXTENSION
+            if qr_format == FORMAT_BBQR:
+                from ...bbqr import encode_bbqr
+
+                qr_payload = encode_bbqr(serialized, encoding="H", file_type="P")
+            elif qr_format == FORMAT_UR:
+                from uUR import UR, Types
+
+                qr_payload = UR(Types.CRYPTO_PSBT_TYPE, Types.psbt_to_cbor(serialized))
+            else:
+                qr_payload = base_encode(serialized, 64)
+
+        self._export_signature(
+            serialized,
+            qr_format,
+            message_filename,
+            message,
+            address,
+            sd_binary_extension,
+            qr_payload,
+        )
+
+        return MENU_CONTINUE
+
+    def sign_message(self):
+        """Sign message using sparrow Raw/Electrum/Trezor(BIP137) and BIP322 modes"""
+        from krux import bip322
+
+        data, qr_format, message_filename = self._load_message()
         if data is None:
             self.flash_error(t("Failed to load"))
             return MENU_CONTINUE
 
+        # Treat message as psbt (BIP322)
+        parsed_psbt = self._try_parse_psbt(data)
+        if parsed_psbt is not None:
+            if not bip322.check_bip322_psbt(parsed_psbt):
+                self.flash_error(t("Failed to load"))
+                return MENU_CONTINUE
+            return self._sign_bip322_message(parsed_psbt, qr_format, message_filename)
+
+        # Treat as message simple txt
+        # (raw, Electrum, Trezor(BIP137) modes on Sparrow) or
+        # a generic
         if message_filename:
             signature_data = self._sign_at_address_from_sd(data)
             if signature_data:
@@ -387,13 +566,20 @@ class SignMessage(Utils):
                 )
                 return MENU_CONTINUE
 
-        data = data.encode() if isinstance(data, str) else data
-        signature_data = self._sign_at_address_from_qr(data)
+        # UR objects etc. cannot be signed as text
+        if not isinstance(data, (str, bytes, bytearray)):
+            self.flash_error(t("Failed to load"))
+            return MENU_CONTINUE
+
+        bytes_data = data.encode() if isinstance(data, str) else data
+        signature_data = self._sign_at_address_from_qr(bytes_data)
         if signature_data:
             sig, message, address = signature_data
             self._export_signature(sig, qr_format, message_filename, message, address)
             return MENU_CONTINUE
-        sig = self.sign_standard_message(data)
+
+        # Deal with general messages (raw_hash)
+        sig = self.sign_standard_message(bytes_data)
         if sig:
             self._export_signature(sig, qr_format, message_filename)
         return MENU_CONTINUE

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from embit import bip32, compact, script
+from embit import bip32, script
 from embit.networks import NETWORKS
 import hashlib
 import binascii
@@ -133,7 +133,8 @@ class SignMessage(Utils):
         return addr
 
     def _sign_at_address(self, message, derivation_str, address=""):
-        """Signs a message at a derived Bitcoin address"""
+        """Signs a BIP137 message at a derived Bitcoin address"""
+        from krux import bip137
 
         derivation = bip32.parse_path(derivation_str)
         self._display_message_sign_prompt(
@@ -143,15 +144,8 @@ class SignMessage(Utils):
         if not self.prompt(t("Sign?"), BOTTOM_PROMPT_LINE):
             return None
 
-        message_hash = hashlib.sha256(
-            hashlib.sha256(
-                b"\x18Bitcoin Signed Message:\n"
-                + compact.to_bytes(len(message))
-                + message
-            ).digest()
-        ).digest()
-
-        sig = self.ctx.wallet.key.sign_at(derivation, message_hash)
+        script_type = self.get_script_type_from_path(derivation_str) or "p2pkh"
+        _, sig = bip137.sign(message, self.ctx.wallet.key, derivation, script_type)
         self._display_signature(base_encode(sig, 64))
         return sig
 
@@ -234,6 +228,8 @@ class SignMessage(Utils):
 
     def sign_standard_message(self, data):
         """Signs a standard message"""
+        from krux import bip137
+
         message_hash, is_raw_hash = self._compute_message_hash(data)
         if message_hash is None:
             return ""
@@ -248,6 +244,8 @@ class SignMessage(Utils):
             )
             if not self.prompt(t("Proceed?"), BOTTOM_PROMPT_LINE):
                 return ""
+        else:
+            message_hash = bip137.message_commitment(data)
 
         self.ctx.display.clear()
         self.ctx.display.draw_centered_text(
@@ -257,7 +255,13 @@ class SignMessage(Utils):
         if not self.prompt(t("Sign?"), BOTTOM_PROMPT_LINE):
             return ""
 
-        sig = self.ctx.wallet.key.sign(message_hash).serialize()
+        key = self.ctx.wallet.key
+        if is_raw_hash:
+            sig = key.sign(message_hash).serialize()
+        else:
+            _, sig = bip137.sign(
+                data, key, bip32.parse_path(key.derivation), key.script_type
+            )
         self._display_signature(base_encode(sig, 64))
         return sig
 

--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -2,6 +2,31 @@ from ...shared_mocks import MockPrinter, get_mock_open
 from .. import create_ctx
 from .test_home import tdata
 
+# Pre-built BIP-322 Simple PSBTs for tdata.SINGLESIG_SIGNING_KEY,
+BIP322_P2PKH_PSBT = "cHNidP8BAD0CAAAAAQCT8JL2BtAApmsl1B/zBHFH8tXf9qPfLSK7A6gLAhQsAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBIgAAAAAAAAAAGXapFNmG7QG3oiIlpw7b8rp8+2OhXLOqiKwiBgOq61LddJTDYQSd5nzGgOg+vLu9vrE2N9ks2EX3AwivXhhzxdoKLAAAgAAAAIAAAACAAAAAAAAAAAAAAA=="
+
+BIP322_P2SH_P2WPKH_PSBT = "cHNidP8BAD0CAAAAAdnOujvnNBB4CCjtIYSFBflzrpwyNFOW3QgYqsYSwwlVAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBIAAAAAAAAAAAF6kUP7bpWBLle7RpH5pKYohiphpPdpuHIgYDmztpS4/FteB/sGnHg8rHVPXTjD4IvtGWDjH9sd2jXCQYc8XaCjEAAIAAAACAAAAAgAAAAAAAAAAAAAA="
+
+BIP322_P2WPKH_PSBT = "cHNidP8BAD0CAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIiBgMw1U/Q3UIKbl+NNiT180gsrjUPedXwdTv1vu+cLZGvPBhzxdoKVAAAgAAAAIAAAACAAAAAAAAAAAAAAA=="
+
+BIP322_P2TR_PSBT = "cHNidP8BAD0CAAAAAQ8eLSqZ9cH1Pi5bqoN9Rrwe7JbtPh8nZ+GhDGQTSR9pAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBKwAAAAAAAAAAIlEgpghp8NvPHcZZyc7Lr4BQE16p6M3EhwU/HcaICUncaEwhFsyKS8ZNiXvdxfvC9nD3qLoLOGd5EGzxIjxvxdfNb8EVGQBzxdoKVgAAgAAAAIAAAACAAAAAAAAAAAAAAA=="
+
+INVALID_BIP322_PSBT = "cHNidP8BAFICAAAAARERERERERERERERERERERERERERERERERERERERERERAAAAAAD/////AaCGAQAAAAAAFgAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+INVALID_BIP322_TWO_VINS_PSBT = "cHNidP8BAGYCAAAAApEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////kR2k51XtL6Hjt/65tfojiJoAso6Ok9Lpe53ebaLsktoAAAAAAP////8BAAAAAAAAAAABagAAAAABCQxoZWxsbyBiaXAzMjIAAQEfAAAAAAAAAAAWABTAzrzWw9PKjHXcXsYuvlUzDvkQ4gABAR8AAAAAAAAAABYAFMDOvNbD08qMddxexi6+VTMO+RDiAAA="
+INVALID_BIP322_WRONG_PREVN_PSBT = "cHNidP8BAD0CAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAQAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIAAA=="
+INVALID_BIP322_FUNDED_PSBT = "cHNidP8BAD0CAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////AQEAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIAAA=="
+INVALID_BIP322_NON_OP_RETURN_PSBT = "cHNidP8BAFICAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////AQAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIAAA=="
+INVALID_BIP322_NO_UTXO_PSBT = "cHNidP8BAD0CAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAAA"
+
+# P2PKH with non_witness_utxo (parent tx vout[0] = address spk) instead of witness_utxo.
+BIP322_P2PKH_NON_WITNESS_UTXO_PSBT = "cHNidP8BAD0CAAAAAQCT8JL2BtAApmsl1B/zBHFH8tXf9qPfLSK7A6gLAhQsAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEAVQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/////AAAAAAABAAAAAAAAAAAZdqkU2YbtAbeiIiWnDtvyunz7Y6Fcs6qIrAAAAAAiBgOq61LddJTDYQSd5nzGgOg+vLu9vrE2N9ks2EX3AwivXhhzxdoKLAAAgAAAAIAAAACAAAAAAAAAAAAAAA=="
+
+# Prepared for fingerprint b8688df1 — tdata's fp 73c5da0a doesn't match.
+BIP322_OTHER_WALLET_PSBT = "cHNidP8BAD0CAAAAAcGgKxwXL1jXcIP4vdKJAPjw6N8+KaBi+XHCxdO9slW6AAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAURaXKkYxfBPgdgJnj4ES6lkXFXPkiBgLh6Dn3camvYFVOBD3posWvbavFvR0y8zGXCX3KVI6JVxi4aI3xVAAAgAAAAIAAAACAAAAAAAAAAAAAAA=="
+
+# Valid BIP-322 p2wpkh shape but bip32_derivations stripped.
+BIP322_P2WPKH_NO_DERIV_PSBT = "cHNidP8BAD0CAAAAAZEdpOdV7S+h47f+ubX6I4iaALKOjpPS6Xud3m2i7JLaAAAAAAD/////AQAAAAAAAAAAAWoAAAAAAQkMaGVsbG8gYmlwMzIyAAEBHwAAAAAAAAAAFgAUwM681sPTyox13F7GLr5VMw75EOIAAA=="
+
 
 def test_sign_message(mocker, m5stickv, tdata):
     import binascii
@@ -584,3 +609,311 @@ def test_load_from_sd_card(mocker, m5stickv, tdata):
     sign_msg._export_to_qr.assert_called()
 
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+
+def test_sign_bip322_psbt_menu(mocker, m5stickv, tdata):
+    from krux import bip137, bip322
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+    from krux.qr import FORMAT_NONE
+    from krux.pages.qr_capture import QRCodeCapture
+
+    btn_seq = [
+        BUTTON_ENTER,  # Load from camera
+        BUTTON_ENTER,  # Confirm Sign?
+        BUTTON_ENTER,  # Select "Sign to QR code"
+        BUTTON_ENTER,  # Dismiss QR display
+    ]
+
+    # (script_type, opaque pre-built PSBT, signing module)
+    cases = [
+        ("p2pkh", BIP322_P2PKH_PSBT, bip137),
+        ("p2sh-p2wpkh", BIP322_P2SH_P2WPKH_PSBT, bip137),
+        ("p2wpkh", BIP322_P2WPKH_PSBT, bip322),
+        ("p2tr", BIP322_P2TR_PSBT, bip322),
+    ]
+
+    # `mocker.spy` wraps the live module attribute; re-running it on a
+    # later iteration would try to spy the previous spy and fail with
+    # InvalidSpecError.
+    original_bip137_sign = bip137.sign
+    original_bip322_sign = bip322.sign
+    for i, case in enumerate(cases):
+        print("case %d (%s)" % (i, case[0]))
+        bip137.sign = original_bip137_sign
+        bip322.sign = original_bip322_sign
+
+        wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+        ctx = create_ctx(mocker, btn_seq, wallet)
+
+        home = SignMessage(ctx)
+        mocker.patch.object(
+            QRCodeCapture,
+            "qr_capture_loop",
+            new=lambda self: (case[1], FORMAT_NONE),
+        )
+        mocker.patch.object(home, "has_sd_card", new=lambda: False)
+        mocker.patch.object(
+            home,
+            "display_qr_codes",
+            new=lambda data, qr_format, title=None: ctx.input.wait_for_button(),
+        )
+        mocker.patch.object(home, "print_standard_qr", new=lambda *a, **kw: None)
+        sign_spy = mocker.spy(case[2], "sign")
+        home.sign_message()
+        sign_spy.assert_called_once()
+
+
+def test_sign_bip322_psbt_to_sd(mocker, m5stickv, tdata):
+    from krux import bip322
+    from krux.pages import file_operations
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.qr import FORMAT_NONE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.sd_card import PSBT_FILE_EXTENSION, SIGNED_FILE_SUFFIX
+
+    btn_seq = [
+        BUTTON_ENTER,  # Load from camera
+        BUTTON_ENTER,  # Confirm Sign?
+        BUTTON_PAGE,  # Move to "Sign to SD card"
+        BUTTON_ENTER,  # Press "Sign to SD card"
+    ]
+
+    cases = [
+        ("p2wpkh", BIP322_P2WPKH_PSBT),
+        ("p2tr", BIP322_P2TR_PSBT),
+    ]
+
+    original_serialize = bip322.serialize_bip322
+    for i, case in enumerate(cases):
+        print("case %d (%s)" % (i, case[0]))
+        bip322.serialize_bip322 = original_serialize
+
+        wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+        ctx = create_ctx(mocker, btn_seq, wallet)
+        home = SignMessage(ctx)
+        mocker.patch.object(
+            QRCodeCapture,
+            "qr_capture_loop",
+            new=lambda self, b=case[1]: (b, FORMAT_NONE),
+        )
+        mocker.patch.object(home, "has_sd_card", new=lambda: True)
+        savefile_mock = mocker.MagicMock()
+        mocker.patch.object(file_operations, "SaveFile", return_value=savefile_mock)
+        serialize_spy = mocker.spy(bip322, "serialize_bip322")
+
+        home.sign_message()
+
+        serialize_spy.assert_called_once()
+        savefile_mock.save_file.assert_called_once_with(
+            serialize_spy.spy_return,
+            "message",
+            "",
+            "Signature:",
+            PSBT_FILE_EXTENSION,
+            SIGNED_FILE_SUFFIX,
+            prompt=False,
+            save_as_binary=True,
+        )
+
+
+def test_sign_non_bip322_psbt_fail(mocker, m5stickv, tdata):
+    from krux import bip322
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+    from krux.qr import FORMAT_NONE
+    from krux.pages.qr_capture import QRCodeCapture
+
+    cases = [
+        INVALID_BIP322_PSBT,
+        INVALID_BIP322_TWO_VINS_PSBT,
+        INVALID_BIP322_WRONG_PREVN_PSBT,
+        INVALID_BIP322_FUNDED_PSBT,
+        INVALID_BIP322_NON_OP_RETURN_PSBT,
+        INVALID_BIP322_NO_UTXO_PSBT,
+    ]
+
+    original_check = bip322.check_bip322_psbt
+    for i, psbt_b64 in enumerate(cases):
+        print("Case %d" % i)
+        bip322.check_bip322_psbt = original_check
+
+        wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+        ctx = create_ctx(mocker, [BUTTON_ENTER], wallet)
+        home = SignMessage(ctx)
+        mocker.patch.object(
+            QRCodeCapture,
+            "qr_capture_loop",
+            new=lambda self, b=psbt_b64: (b, FORMAT_NONE),
+        )
+        check_spy = mocker.spy(bip322, "check_bip322_psbt")
+        flash_spy = mocker.spy(home, "flash_error")
+        home.sign_message()
+        check_spy.assert_called_once()
+        assert not check_spy.spy_return
+        flash_spy.assert_called_once()
+
+
+def test_sign_bip322_psbt_accepts_non_witness_utxo(mocker, m5stickv, tdata):
+    from krux import bip137, bip322
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+    from krux.qr import FORMAT_NONE
+    from krux.pages.qr_capture import QRCodeCapture
+
+    btn_seq = [
+        BUTTON_ENTER,  # Load from camera
+        BUTTON_ENTER,  # Confirm Sign?
+        BUTTON_ENTER,  # Select "Sign to QR code"
+        BUTTON_ENTER,  # Dismiss QR display
+    ]
+
+    wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+    ctx = create_ctx(mocker, btn_seq, wallet)
+    home = SignMessage(ctx)
+    mocker.patch.object(
+        QRCodeCapture,
+        "qr_capture_loop",
+        new=lambda self: (BIP322_P2PKH_NON_WITNESS_UTXO_PSBT, FORMAT_NONE),
+    )
+    mocker.patch.object(home, "has_sd_card", new=lambda: False)
+    mocker.patch.object(
+        home,
+        "display_qr_codes",
+        new=lambda data, qr_format, title=None: ctx.input.wait_for_button(),
+    )
+    mocker.patch.object(home, "print_standard_qr", new=lambda *a, **kw: None)
+    check_spy = mocker.spy(bip322, "check_bip322_psbt")
+    sign_spy = mocker.spy(bip137, "sign")
+    home.sign_message()
+    check_spy.assert_called_once()
+    assert check_spy.spy_return
+    sign_spy.assert_called_once()
+
+
+def test_sign_bip322_psbt_from_qrcodes(mocker, m5stickv, tdata):
+    import base64
+    from krux import bip322
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+    from krux.qr import FORMAT_UR, FORMAT_BBQR
+    from krux.pages.qr_capture import QRCodeCapture
+    from ur.ur import UR
+    from urtypes.crypto import PSBT as URPSBT
+
+    cases = [
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER] * 6,
+            BIP322_P2WPKH_PSBT,
+            FORMAT_UR,
+        ),
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER] * 6,
+            BIP322_P2TR_PSBT,
+            FORMAT_UR,
+        ),
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER] * 6,
+            BIP322_P2WPKH_PSBT,
+            FORMAT_BBQR,
+        ),
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER] * 6,
+            BIP322_P2TR_PSBT,
+            FORMAT_BBQR,
+        ),
+    ]
+
+    original_bip322_sign = bip322.sign
+    for i, case in enumerate(cases):
+        print("Case %d: %s" % (i, case))
+        bip322.sign = original_bip322_sign
+
+        raw = base64.b64decode(case[2])
+        if case[3] == FORMAT_UR:
+            raw = UR("crypto-psbt", URPSBT(raw).to_cbor())
+
+        wallet = Wallet(case[0])
+        ctx = create_ctx(mocker, case[1], wallet)
+        home = SignMessage(ctx)
+        mocker.patch.object(
+            QRCodeCapture,
+            "qr_capture_loop",
+            new=lambda self, r=raw, f=case[3]: (r, f),
+        )
+        mocker.patch.object(home, "has_sd_card", new=lambda: False)
+        mocker.patch.object(
+            home,
+            "display_qr_codes",
+            new=lambda data, qr_format, title=None: ctx.input.wait_for_button(),
+        )
+        mocker.patch.object(home, "print_standard_qr", new=lambda *a, **kw: None)
+        sign_spy = mocker.spy(bip322, "sign")
+        home.sign_message()
+        sign_spy.assert_called_once()
+
+
+def test_sign_bip322_psbt_fail(mocker, m5stickv, tdata):
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.qr import FORMAT_NONE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+
+    cases = [
+        # Just decline sign
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER, BUTTON_PAGE],
+            BIP322_P2WPKH_PSBT,
+            None,
+        ),
+        # Key on psbt do not have derivation
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER, BUTTON_ENTER],
+            BIP322_P2WPKH_NO_DERIV_PSBT,
+            "Key not match PSBT",
+        ),
+        # Keys derivations differ
+        (
+            tdata.SINGLESIG_SIGNING_KEY,
+            [BUTTON_ENTER, BUTTON_ENTER],
+            BIP322_OTHER_WALLET_PSBT,
+            "Key not match PSBT",
+        ),
+        # Same, but swapped
+        (
+            tdata.SINGLESIG_ACTION_KEY,
+            [BUTTON_ENTER, BUTTON_ENTER],
+            BIP322_P2PKH_PSBT,
+            "Failed to load",
+        ),
+    ]
+
+    for i, case in enumerate(cases):
+        print("Case %d: %s" % (i, case))
+        wallet = Wallet(case[0])
+        ctx = create_ctx(mocker, case[1], wallet)
+        home = SignMessage(ctx)
+        mocker.patch.object(
+            QRCodeCapture,
+            "qr_capture_loop",
+            new=lambda self, b=case[2]: (b, FORMAT_NONE),
+        )
+        flash_spy = mocker.spy(home, "flash_error")
+        home.sign_message()
+        if case[3] is None:
+            flash_spy.assert_not_called()
+        else:
+            flash_spy.assert_called_once_with(case[3])

--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -68,7 +68,7 @@ def test_sign_message(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Hex Public Key Text
                 BUTTON_ENTER,  # PK QR code
             ],
-            "MEQCIHKmpv1+vgPpFTN0JXjyrMK2TtLHVeJJ2TydPYmEt0RnAiBJVt/Y61ef5VlWjG08zf92AeF++BWdYm1Yd9IEy2cSqA==",
+            "KNDYjnAavccLPKVJ7u6RjWs9n2NzN+kHc8MHrrUiQRq9TEoXa3UAbwsjESNCi7wcAZ9Vw1N7K+ujZzasgEgsvL0=",
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
             None,
         ),
@@ -86,7 +86,7 @@ def test_sign_message(mocker, m5stickv, tdata):
                 BUTTON_ENTER,  # Hex Public Key Text
                 BUTTON_ENTER,  # PK QR code
             ],
-            "MEQCIEHpCMfQ+5mBAOH//OCxF6iojpVtIS6G7X+3r3qB/0CaAiAkbjW2SGrPLvju+O05yH2x/4EKL2qlkdWnquiVkUY3jQ==",
+            "KIyFNagItWNotujcQQ7AoXLO90ndVEmsQvXeJbaTnFKufb2eq+G1RKvxRw+eR887Rn0UgqAKyrji4GQQYGfxvkw=",
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
             None,
         ),
@@ -167,11 +167,11 @@ def test_sign_message(mocker, m5stickv, tdata):
                 BUTTON_PAGE_PREV,  # Move to "Go"
                 BUTTON_ENTER,  # Press "Go" (saved pubkey to SD)
             ],
-            "MEQCIHKmpv1+vgPpFTN0JXjyrMK2TtLHVeJJ2TydPYmEt0RnAiBJVt/Y61ef5VlWjG08zf92AeF++BWdYm1Yd9IEy2cSqA==",  # 4 base64 for display_qr_codes / print_qr_prompt
+            "KNDYjnAavccLPKVJ7u6RjWs9n2NzN+kHc8MHrrUiQRq9TEoXa3UAbwsjESNCi7wcAZ9Vw1N7K+ujZzasgEgsvL0=",  # 4 base64 for display_qr_codes / print_qr_prompt
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",  # 5 pubkey for display_qr_codes / print_qr_prompt
             # 6 SD file
             binascii.b2a_base64(
-                "MEQCIHKmpv1+vgPpFTN0JXjyrMK2TtLHVeJJ2TydPYmEt0RnAiBJVt/Y61ef5VlWjG08zf92AeF++BWdYm1Yd9IEy2cSqA==".encode(
+                "KNDYjnAavccLPKVJ7u6RjWs9n2NzN+kHc8MHrrUiQRq9TEoXa3UAbwsjESNCi7wcAZ9Vw1N7K+ujZzasgEgsvL0=".encode(
                     "utf-8"
                 ),
                 newline=False,
@@ -206,7 +206,6 @@ def test_sign_message(mocker, m5stickv, tdata):
             with patch(
                 "builtins.open", new=get_mock_open({"/sd/signed-message.sig": case[6]})
             ) as mock_file:
-
                 # function being tested
                 home.sign_message()
 
@@ -263,7 +262,7 @@ def test_sign_message_invalid_derivations(mocker, m5stickv, tdata):
             ],
             "signmessage m84h ascii:hello",
             "m84h",
-            "MEQCIA7DCCFox6tQqC3GE9a5IMvm8cVu1Zh6OWcUE1gls77gAiAzLncevU9FFJRvG83ahSJ8hISimgtSSdRHye2rmijwlg==",
+            "J7jAswueRmlhh64HDmfIuVvo5pcMMgBYdSCXAnMh2NQsQUwYkyI1O8G0F/8ChIiOz2pfCiQwE0FfOXWTAtMsMDE=",
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
         ),
         (
@@ -278,7 +277,7 @@ def test_sign_message_invalid_derivations(mocker, m5stickv, tdata):
             ],
             "signmessage m/8xh/0/0 ascii:hello",
             "m/8xh/0/0",
-            "MEQCIDL/XdIRF+v0wnN/JDOu2XYMTYqJaAyjuIDdSG4E/909AiASARSc1zfJsvUKC6MDQlM3E2lrkTx3iYfpJUWRZy/Vpg==",
+            "JwdAF2MY6uglo4E3Wxbbi9G6NyrEna4LyYBsUueJg8yoLQm39BHDJ+ulgRhXl2RI/BManG05oTmRyXOqjDfDrs0=",
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
         ),
         (  # 2 - QR invalid (empty segment)
@@ -293,15 +292,13 @@ def test_sign_message_invalid_derivations(mocker, m5stickv, tdata):
             ],
             "signmessage m//0 ascii:hello",
             "m//0",
-            "MEQCIDx4K8atJhGiaFdCCsgaUqFv22ncJ3AFHczFsNLZmbcGAiBuQdB5/pztOHjyQt0DKmuMKo799raQuRrXMVKK69ELjQ==",
+            "J0yYgnVLwEditYd+QwmJrXqFRplrBqfUfUHOpAF4m+EEW9MYf4BVp/SWPujLDYfQKWxbpRPVZdaYuyGm77bNSsE=",
             "02707a62fdacc26ea9b63b1c197906f56ee0180d0bcf1966e1a2da34f5f3a09a9b",
         ),
     ]
 
-    n = 0
-    for case in cases:
+    for n, case in enumerate(cases):
         print("Case: ", n)
-        n = 0
 
         # A mainnet wallet
         wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
@@ -372,7 +369,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             False,
             "a test message with a colon ':' character.",
             "3. bc1qgl5…3cn3",  # bc1qgl5vlg0zdl7yvprgxj9fevsc6q6x5dmcyk3cn3
-            "IN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
+            "KN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
         ),
         (  # 1 - Sign P2WPKH Testnet
             [
@@ -387,7 +384,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             False,
             "A test message.",
             "3. tb1qynp…m5km",
-            "ILc30ti8OPSpCtzfj7sNnftANBCuVpyRX7pnM3iAgOk9F9IUtnXNPus0+MF12y5HKYHAB6IVYr66sLmL3Vi3oEE=",
+            "KLc30ti8OPSpCtzfj7sNnftANBCuVpyRX7pnM3iAgOk9F9IUtnXNPus0+MF12y5HKYHAB6IVYr66sLmL3Vi3oEE=",
         ),
         (  # 2 - Sign P2TR Mainnet
             [
@@ -432,7 +429,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             False,
             "a test message with a colon ':' character.",
             "3. 38CahkV…sEAN",
-            "HyH8898c2S6eF8hTPGhRqLC6UQrJrhw/fdguBeFG0cCrOFkbG8TCVURXOgxXaEV93vrFlHyxNGEvL10IcsLtvvI=",
+            "IyH8898c2S6eF8hTPGhRqLC6UQrJrhw/fdguBeFG0cCrOFkbG8TCVURXOgxXaEV93vrFlHyxNGEvL10IcsLtvvI=",
         ),
         (  # 5 - Sign P2WPKH Mainnet - Save to SD card
             [
@@ -449,7 +446,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             True,  # Sign to SD
             "A test message.",
             "3. bc1qgl5…3cn3",
-            "IN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
+            "KN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
         ),
         (  # 6 - Sign P2WPKH Mainnet - Load from and save to SD card
             [
@@ -468,7 +465,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             True,  # Sign to SD
             "A test message.",
             "3. bc1qgl5…3cn3",
-            "IN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
+            "KN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
         ),
         (  # 7 - Sign empty - Load from and save to SD card
             [
@@ -488,7 +485,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
             True,  # Sign to SD
             "A test message.",
             "3. bc1qgl…cn3",
-            "IN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
+            "KN/4LmcGRaI5sgvBP2mrTXQFvD6FecXd8La03SixPabsb/255ElRGTcXhicT3KFsNJbfQ9te909ZXeKMaqUcaPM=",
         ),
     ]
     case_count = 0
@@ -532,7 +529,7 @@ def test_sign_message_at_address(mocker, m5stickv, tdata):
 
         if case[2] != b"":
             ctx.display.draw_hcentered_text.assert_has_calls(
-                [mocker.call("Message:", 10, theme.highlight_color)]
+                [mocker.call("Message:", mocker.ANY, theme.highlight_color)]
             )
             ctx.display.draw_hcentered_text.assert_has_calls(
                 [mocker.call(case[4], mocker.ANY, max_lines=10)]
@@ -577,20 +574,12 @@ def test_load_from_sd_card(mocker, m5stickv, tdata):
 
     ctx = create_ctx(mocker, btn_seq, wallet)
     sign_msg = SignMessage(ctx)
-
-    # test sign at address with binary content (it can't be decoded to UTF8 and it is not sign to address)
-    sign_msg._sign_at_address_from_sd(file_content) == None
-
-    # mock load of file
+    assert sign_msg._sign_at_address_from_sd(file_content) is None
     sign_msg._load_message = lambda: (file_content, FORMAT_NONE, filename)
 
     mocker.spy(sign_msg, "_export_signature")
     mocker.spy(sign_msg, "_export_to_qr")
-
-    # Successful sign a binary (that can't be decoded) from sd card
     sign_msg.sign_message()
-
-    # Assert signature sucessfully exported to QR
     sign_msg._export_signature.assert_called()
     sign_msg._export_to_qr.assert_called()
 

--- a/tests/test_bip137.py
+++ b/tests/test_bip137.py
@@ -1,0 +1,298 @@
+import pytest
+
+from .pages.home_pages.test_home import tdata
+
+P2PKH_DERIV = "m/44h/0h/0h/0/3"
+P2SH_P2WPKH_DERIV = "m/49h/0h/0h/0/3"
+P2WPKH_DERIV = "m/84h/0h/0h/0/3"
+P2TR_DERIV = "m/86h/0h/0h/0/3"
+
+MESSAGE = b"krux+bip137"
+
+
+@pytest.fixture
+def address_for():
+    def _addr(pub, script_type, network):
+        from embit import script
+
+        if script_type == "p2pkh":
+            return script.p2pkh(pub).address(network=network)
+        if script_type == "p2sh-p2wpkh":
+            return script.p2sh(script.p2wpkh(pub)).address(network=network)
+        if script_type == "p2wpkh":
+            return script.p2wpkh(pub).address(network=network)
+        if script_type == "p2tr":
+            return script.p2tr(pub).address(network=network)
+        return None
+
+    return _addr
+
+
+@pytest.fixture
+def fake_raw_sig():
+    def _sig(recid):
+        import secrets
+        from krux.bip137 import P2PKH_HEADER
+
+        return bytes([P2PKH_HEADER + recid]) + secrets.token_bytes(64)
+
+    return _sig
+
+
+@pytest.fixture
+def lenient_sign():
+    def _sign(key, derivation, message):
+        import hashlib
+        from embit import compact
+        from krux.bip137 import MESSAGE_MAGIC
+
+        commitment = hashlib.sha256(
+            hashlib.sha256(
+                MESSAGE_MAGIC + compact.to_bytes(len(message)) + message
+            ).digest()
+        ).digest()
+        sig = key.sign_at(derivation, commitment)
+        return (commitment, sig)
+
+    return _sign
+
+
+# An idealized strict verifier (Sparrow >=2.5.x).
+#
+# The numbers are defined in BIP137 and means and
+# each one produces different check addresses:
+#
+# - 27-30: uncompressed-pubkey p2pkh
+# - 31-34: compressed-pubkey p2pkh
+# - 35-38: compressed-pubkey p2sh-p2wpkh (p2sh ones are found here)
+# - >38: compressed-pubkey p2wpkh and beyond
+@pytest.fixture
+def strict_verify(address_for):
+    def _verify(sig, commitment, expected_address, network):
+        from embit import ec
+        from embit.util import secp256k1
+
+        header = sig[0]
+        if not 27 <= header <= 42:
+            return False
+
+        recid = (header - 27) & 3
+        if 27 <= header <= 30:
+            script_type, flag = "p2pkh", secp256k1.EC_UNCOMPRESSED
+        elif 31 <= header <= 34:
+            script_type, flag = "p2pkh", secp256k1.EC_COMPRESSED
+        elif 35 <= header <= 38:
+            script_type, flag = "p2sh-p2wpkh", secp256k1.EC_COMPRESSED
+        else:
+            script_type, flag = "p2wpkh", secp256k1.EC_COMPRESSED
+
+        parsed = secp256k1.ecdsa_recoverable_signature_parse_compact(sig[1:], recid)
+        raw = secp256k1.ecdsa_recover(parsed, commitment)
+        pub = ec.PublicKey.parse(secp256k1.ec_pubkey_serialize(raw, flag))
+        addr = address_for(pub, script_type, network)
+        return addr is not None and addr == expected_address
+
+    return _verify
+
+
+# Idealized lenient verifier (Sparrow  <2.5.x/ Electrum).
+#
+# By lenient we mean that the verification still occurs for recids and flags,
+# but the script type and thus address, will be trusted by a provided script
+# type, not by a checked one.
+@pytest.fixture
+def lenient_verify(address_for):
+    def _verify(sig, commitment, expected_address, network, script_type):
+        from embit import ec
+        from embit.util import secp256k1
+
+        header = sig[0]
+        if not 27 <= header <= 42:
+            return False
+        recid = (header - 27) & 3
+        flag = (
+            secp256k1.EC_UNCOMPRESSED if 27 <= header <= 30 else secp256k1.EC_COMPRESSED
+        )
+
+        parsed = secp256k1.ecdsa_recoverable_signature_parse_compact(sig[1:], recid)
+        raw = secp256k1.ecdsa_recover(parsed, commitment)
+        pub = ec.PublicKey.parse(secp256k1.ec_pubkey_serialize(raw, flag))
+        addr = address_for(pub, script_type, network)
+        return addr is not None and addr == expected_address
+
+    return _verify
+
+
+def test_message_commitment(mocker, m5stickv, tdata):
+    import binascii
+    from krux.bip137 import message_commitment
+
+    assert binascii.hexlify(message_commitment(MESSAGE)) == (
+        b"6f47a0896ff0eb30d36d73ef8783f9796abc01328807835eb258ee042094df22"
+    )
+
+
+def test_build_header(mocker, m5stickv, fake_raw_sig):
+    from krux.bip137 import (
+        build_header,
+        P2PKH_HEADER,
+        P2SH_P2WPKH_HEADER,
+        P2WPKH_HEADER,
+    )
+
+    # (script_type, expected_header_base)
+    cases = [
+        ("p2pkh", P2PKH_HEADER),
+        ("p2sh-p2wpkh", P2SH_P2WPKH_HEADER),
+        ("p2wpkh", P2WPKH_HEADER),
+        # lenient ones could sign p2tr using this conversion
+        ("p2tr", P2PKH_HEADER),
+        ("p2wsh", P2PKH_HEADER),
+    ]
+    for i, case in enumerate(cases):
+        print("Case: %d", i)
+        for recid in range(4):
+            assert build_header(fake_raw_sig(recid), case[0]) == case[1] + recid
+
+
+def test_fail_build_header(mocker, m5stickv):
+    from krux.bip137 import build_header
+
+    for bad in (0, 26, 35, 255):
+        raw = bytes([bad]) + b"\x00" * 64
+        with pytest.raises(ValueError, match="Invalid sig header"):
+            build_header(raw, "p2pkh")
+
+
+def test_lenient_signatures(mocker, m5stickv, tdata, lenient_sign):
+    from embit import bip32
+    from krux.bip137 import (
+        sign,
+        P2PKH_HEADER,
+        P2SH_P2WPKH_HEADER,
+        P2WPKH_HEADER,
+    )
+
+    # (derivation, script_type, current_header_base)
+    cases = [
+        (P2PKH_DERIV, "p2pkh", P2PKH_HEADER),
+        (P2SH_P2WPKH_DERIV, "p2sh-p2wpkh", P2SH_P2WPKH_HEADER),
+        (P2WPKH_DERIV, "p2wpkh", P2WPKH_HEADER),
+        # lenient ones could sign p2tr using this conversion
+        (P2TR_DERIV, "p2tr", P2PKH_HEADER),
+    ]
+    key = tdata.SINGLESIG_SIGNING_KEY
+    for i, case in enumerate(cases):
+        print("Case: %d ", i)
+        derivation_str, script_type, current_header_base = case
+        derivation = bip32.parse_path(derivation_str)
+
+        lenient_commitment, lenient_sig = lenient_sign(key, derivation, MESSAGE)
+        strict_commitment, strict_sig = sign(MESSAGE, key, derivation, script_type)
+
+        assert lenient_commitment == strict_commitment
+
+        # lenient sigs should sig on lenient verifiers
+        assert 31 <= lenient_sig[0] <= 34
+        lenient_recid = lenient_sig[0] - P2PKH_HEADER
+        strict_recid = strict_sig[0] - case[2]
+        assert lenient_recid == strict_recid
+        assert strict_sig[0] == case[2] + strict_recid
+        assert lenient_sig[1:] == strict_sig[1:]
+
+
+def test_strict_signatures(
+    mocker,
+    m5stickv,
+    tdata,
+    address_for,
+    lenient_sign,
+    lenient_verify,
+    strict_verify,
+):
+    from embit import bip32
+    from embit.networks import NETWORKS
+    from krux.bip137 import sign
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    network = NETWORKS["main"]
+
+    # Now we will not rely on provided script type
+    # (derivation, script_type) to strict_verify and lenient_verify
+    cases = [
+        (P2PKH_DERIV, "p2pkh"),
+        (P2SH_P2WPKH_DERIV, "p2sh-p2wpkh"),
+        (P2WPKH_DERIV, "p2wpkh"),
+        (P2TR_DERIV, "p2tr"),
+    ]
+
+    for i, case in enumerate(cases):
+        print("Case %d, script=%s" % (i, case[1]))
+        derivation = bip32.parse_path(case[0])
+        pub = key.root.derive(derivation).to_public().key
+        addr = address_for(pub, case[1], network)
+
+        old_commitment, old_sig = lenient_sign(key, derivation, MESSAGE)
+        new_commitment, new_sig = sign(MESSAGE, key, derivation, case[1])
+
+        if case[1] == "p2pkh":
+            # build_header returns P2PKH_HEADER; old_sig == new_sig bytewise
+            assert strict_verify(new_sig, new_commitment, addr, network)
+            assert lenient_verify(new_sig, new_commitment, addr, network, case[1])
+        elif case[1] == "p2tr":
+            # Strict rejects (BIP-137 has no taproot scheme)
+            assert not strict_verify(new_sig, new_commitment, addr, network)
+            assert lenient_verify(new_sig, new_commitment, addr, network, case[1])
+        else:
+            # Strict accepts only the new form; lenient accepts both old
+            # and new header formats (for Sparrow <2.5.x / Electrum compatibility).
+            assert not strict_verify(old_sig, old_commitment, addr, network)
+            assert strict_verify(new_sig, new_commitment, addr, network)
+            assert lenient_verify(old_sig, old_commitment, addr, network, case[1])
+            assert lenient_verify(new_sig, new_commitment, addr, network, case[1])
+
+
+def test_verify_uncompressed_p2pkh(
+    mocker, m5stickv, tdata, lenient_sign, strict_verify, lenient_verify
+):
+    from embit import bip32, script
+    from embit.networks import NETWORKS
+    from krux.bip137 import (
+        P2PKH_HEADER,
+        P2PKH_UNCOMPRESSED_HEADER,
+        sign,
+    )
+
+    # Same secret, two distinct p2pkh addresses (compressed && uncompressed)
+    key = tdata.SINGLESIG_SIGNING_KEY
+    network = NETWORKS["main"]
+    derivation = bip32.parse_path(P2PKH_DERIV)
+    pub = key.root.derive(derivation).to_public().key
+
+    # compressed addr from uncompressed key
+    compressed_addr = script.p2pkh(pub).address(network=network)
+    pub.compressed = False
+    uncompressed_addr = script.p2pkh(pub).address(network=network)
+
+    # check if the compressed addr not match the uncompressed addr one
+    assert compressed_addr != uncompressed_addr
+
+    lenient_commitment, lenient_sig = lenient_sign(key, derivation, MESSAGE)
+    uncompressed_commitment, uncompressed_sig = sign(
+        MESSAGE, key, derivation, "p2pkh", compressed=False
+    )
+
+    assert uncompressed_sig[0] >= P2PKH_UNCOMPRESSED_HEADER
+    assert uncompressed_sig[0] < P2PKH_HEADER
+    assert strict_verify(
+        uncompressed_sig, uncompressed_commitment, uncompressed_addr, network
+    )
+    assert lenient_verify(
+        uncompressed_sig, uncompressed_commitment, uncompressed_addr, network, "p2pkh"
+    )
+    assert not strict_verify(
+        lenient_sig, lenient_commitment, uncompressed_addr, network
+    )
+    assert not lenient_verify(
+        lenient_sig, lenient_commitment, uncompressed_addr, network, "p2pkh"
+    )

--- a/tests/test_bip322.py
+++ b/tests/test_bip322.py
@@ -1,0 +1,472 @@
+import pytest
+
+from .pages.home_pages.test_home import tdata
+
+P2PKH_DERIV = "m/44h/0h/0h/0/0"
+P2SH_P2WPKH_DERIV = "m/49h/0h/0h/0/0"
+P2WPKH_DERIV = "m/84h/0h/0h/0/0"
+P2TR_DERIV = "m/86h/0h/0h/0/0"
+
+MESSAGE = b"krux+bip322"
+
+
+@pytest.fixture
+def scriptpubkey_for():
+    def _spk(pub, script_type):
+        from embit import script
+
+        if script_type == "p2pkh":
+            return script.p2pkh(pub)
+        if script_type == "p2sh-p2wpkh":
+            return script.p2sh(script.p2wpkh(pub))
+        if script_type == "p2wpkh":
+            return script.p2wpkh(pub)
+        if script_type == "p2tr":
+            return script.p2tr(pub)
+        return None
+
+    return _spk
+
+
+@pytest.fixture
+def unsigned_non_bip322_psbt(scriptpubkey_for):
+    def _build(key, derivation_str, script_type, message):
+        from embit.psbt import PSBT
+        from embit.script import Script
+        from embit.transaction import (
+            Transaction,
+            TransactionInput,
+            TransactionOutput,
+        )
+
+        tx = Transaction(
+            version=2,
+            vin=[
+                TransactionInput(
+                    txid=b"\x11" * 32,
+                    vout=0,
+                    script_sig=Script(b""),
+                    sequence=0xFFFFFFFF,
+                )
+            ],
+            vout=[
+                TransactionOutput(
+                    value=100_000,
+                    script_pubkey=Script(b"\x00\x14" + b"\x00" * 20),
+                )
+            ],
+            locktime=0,
+        )
+        return PSBT(tx)
+
+    return _build
+
+
+@pytest.fixture
+def unsigned_bip322_psbt(scriptpubkey_for):
+    # Accepts either:
+    #   - a krux Key
+    #   - a raw `ec.PrivateKey`
+    def _build(key, derivation_str, script_type, message):
+        from embit import bip32
+        from embit.psbt import PSBT, DerivationPath
+        from krux.bip322 import (
+            PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE,
+            build_bip322_txs,
+        )
+
+        if hasattr(key, "root"):
+            derivation = bip32.parse_path(derivation_str)
+            pub = key.root.derive(derivation).to_public().key
+            fingerprint = key.root.my_fingerprint
+        else:
+            pub = key.get_public_key()
+            derivation = None
+            fingerprint = None
+        spk = scriptpubkey_for(pub, script_type)
+
+        to_spend, to_sign = build_bip322_txs(message, spk)
+
+        # embit's PSBT.__init__ uses a `unknown={}` — mutating
+        # `psbt.unknown`. It leaks the entry into every later test suite
+        psbt = PSBT(to_sign, unknown={PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE: message})
+        psbt.inputs[0].witness_utxo = to_spend.vout[0]
+
+        if fingerprint is not None:
+            derivation_path = DerivationPath(fingerprint, derivation)
+            if script_type == "p2tr":
+                psbt.inputs[0].taproot_bip32_derivations[pub] = ([], derivation_path)
+            else:
+                psbt.inputs[0].bip32_derivations[pub] = derivation_path
+
+        return psbt
+
+    return _build
+
+
+def test_check_bip322_psbt(mocker, m5stickv, tdata, unsigned_bip322_psbt):
+    from krux.bip322 import check_bip322_psbt
+
+    # (derivation, script_type)
+    cases = [
+        (P2PKH_DERIV, "p2pkh"),
+        (P2SH_P2WPKH_DERIV, "p2sh-p2wpkh"),
+        (P2WPKH_DERIV, "p2wpkh"),
+        (P2TR_DERIV, "p2tr"),
+    ]
+    key = tdata.SINGLESIG_SIGNING_KEY
+    for i, case in enumerate(cases):
+        print("test_check_bip322_psbt: case %d, script=%s" % (i, case[1]))
+        psbt = unsigned_bip322_psbt(key, case[0], case[1], MESSAGE)
+        assert check_bip322_psbt(psbt)
+
+
+def test_check_bip322_fail(mocker, m5stickv, tdata, unsigned_non_bip322_psbt):
+    from krux.bip322 import check_bip322_psbt
+
+    cases = [
+        (P2PKH_DERIV, "p2pkh"),
+        (P2SH_P2WPKH_DERIV, "p2sh-p2wpkh"),
+        (P2WPKH_DERIV, "p2wpkh"),
+        (P2TR_DERIV, "p2tr"),
+    ]
+    key = tdata.SINGLESIG_SIGNING_KEY
+    for i, case in enumerate(cases):
+        print("test_check_bip322_psbt: case %d, script=%s" % (i, case[1]))
+        psbt = unsigned_non_bip322_psbt(key, case[0], case[1], MESSAGE)
+        assert not check_bip322_psbt(psbt)
+
+
+def test_bip322_vectors(mocker, m5stickv, unsigned_bip322_psbt):
+    from embit import ec, script
+    from embit.script import Witness
+    from embit.transaction import SIGHASH
+    from krux.bip322 import finalize_simple
+
+    # Spec raw WIFs
+    # (wif, script_type, expected_address, messages)
+    cases = [
+        (
+            "L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k",
+            "p2wpkh",
+            "bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l",
+            [b"", b"Hello World"],
+        ),
+        (
+            "KyrSGCFPhqZMjCe5fNTYddiLMp4tMj4gLKuJ26TsB2rvr1VJGPbt",
+            "p2tr",
+            "bc1pss0zhytly75awhm6x2hhvd5lnzv3vssgrf9axfheq8ldyzn88ges79fler",
+            [b"No prefix fallback"],
+        ),
+    ]
+
+    for i, case in enumerate(cases):
+        wif, script_type, expected_addr, messages = case
+        prv = ec.PrivateKey.from_wif(wif)
+        pub = prv.get_public_key()
+        if script_type == "p2wpkh":
+            spk = script.p2wpkh(pub)
+        if script_type == "p2tr":
+            spk = script.p2tr(pub)
+        assert spk.address() == expected_addr
+
+        for j, message in enumerate(messages):
+            print("Case %d (%s): message=%s" % (i, script_type, message))
+
+            psbt = unsigned_bip322_psbt(prv, None, script_type, message)
+            to_sign = psbt.tx
+
+            if script_type == "p2wpkh":
+                code_script = script.p2pkh_from_p2wpkh(spk)
+                sighash = to_sign.sighash_segwit(
+                    input_index=0,
+                    script_pubkey=code_script,
+                    value=0,
+                    sighash=SIGHASH.ALL,
+                )
+                sig = prv.sign(sighash).serialize() + bytes([SIGHASH.ALL])
+                psbt.inputs[0].partial_sigs[pub] = sig
+            if script_type == "p2tr":
+                sighash = to_sign.sighash_taproot(
+                    input_index=0,
+                    script_pubkeys=[spk],
+                    values=[0],
+                    sighash=SIGHASH.ALL,
+                )
+                tweaked_prv = prv.taproot_tweak(b"")
+                sig = tweaked_prv.schnorr_sign(sighash).serialize() + bytes(
+                    [SIGHASH.ALL]
+                )
+                psbt.inputs[0].taproot_key_sig = sig
+                psbt.inputs[0].final_scriptwitness = Witness([sig])
+
+            finalize_simple(psbt, pub)
+
+            witness = psbt.inputs[0].final_scriptwitness
+            if script_type == "p2wpkh":
+                assert len(witness.items) == 2
+                sig_with_sighash, pub_bytes = witness.items
+                assert sig_with_sighash[-1] == SIGHASH.ALL
+                assert pub_bytes == pub.sec()
+                sig_obj = ec.Signature.parse(sig_with_sighash[:-1])
+                assert pub.verify(sig_obj, sighash)
+            if script_type == "p2tr":
+                assert len(witness.items) == 1
+                assert len(witness.items[0]) == 65
+                assert witness.items[0][-1] == SIGHASH.ALL
+                tweaked_pub = pub.taproot_tweak(b"")
+                assert tweaked_pub.schnorr_verify(
+                    ec.SchnorrSig(witness.items[0][:-1]), sighash
+                )
+
+
+def test_sign_finalizes(mocker, m5stickv, tdata, unsigned_bip322_psbt):
+    from krux import bip322
+
+    # (derivation, script_type, has_scriptsig, has_witness)
+    cases = [
+        (P2PKH_DERIV, "p2pkh"),
+        (P2SH_P2WPKH_DERIV, "p2sh-p2wpkh"),
+        (P2WPKH_DERIV, "p2wpkh"),
+        (P2TR_DERIV, "p2tr"),
+    ]
+    key = tdata.SINGLESIG_SIGNING_KEY
+    for i, case in enumerate(cases):
+        print("Case %d, script=%s" % (i, case[1]))
+        psbt = unsigned_bip322_psbt(key, case[0], case[1], MESSAGE)
+        bip322.sign(psbt, key)
+
+        inp = psbt.inputs[0]
+        if case[1] in ("p2pkh", "p2sh-p2wpkh"):
+            assert inp.final_scriptsig is not None
+            assert len(inp.final_scriptsig.data) > 0
+        else:
+            assert inp.final_scriptsig is None or len(inp.final_scriptsig.data) == 0
+
+        if case[1] in ("p2sh-p2wpkh", "p2wpkh", "p2tr"):
+            assert inp.final_scriptwitness is not None
+            assert len(inp.final_scriptwitness.items) >= 1
+        else:
+            assert (
+                inp.final_scriptwitness is None
+                or len(inp.final_scriptwitness.items) == 0
+            )
+
+
+def test_sign_rejects_non_bip322_psbt(
+    mocker, m5stickv, tdata, unsigned_non_bip322_psbt
+):
+    from krux.bip322 import sign
+
+    psbt = unsigned_non_bip322_psbt(None, None, None, MESSAGE)
+    with pytest.raises(ValueError, match="Not a BIP-322 PSBT"):
+        sign(psbt, tdata.SINGLESIG_SIGNING_KEY)
+
+
+def test_sign_raises_when_no_matching_derivation(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from collections import OrderedDict
+    from krux.bip322 import sign
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    pub, deriv = next(iter(psbt.inputs[0].bip32_derivations.items()))
+    fake = type(deriv)(b"\xff" * 4, deriv.derivation)
+    psbt.inputs[0].bip32_derivations = OrderedDict([(pub, fake)])
+    with pytest.raises(ValueError, match="Key not match PSBT"):
+        sign(psbt, key)
+
+
+def test_finalize_simple_raises_without_partial_sigs(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import finalize_simple
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    pub = next(iter(psbt.inputs[0].bip32_derivations))
+    assert not psbt.inputs[0].partial_sigs
+    assert psbt.inputs[0].final_scriptwitness is None
+    with pytest.raises(ValueError, match="PSBT no signatures"):
+        finalize_simple(psbt, pub)
+
+
+def test_finalize_simple_ignores_other_partial_sigs(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from embit import ec
+    from krux.bip322 import finalize_simple
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    real_pub = next(iter(psbt.inputs[0].bip32_derivations))
+    fake_pub = ec.PrivateKey(b"\x01" * 32).get_public_key()
+    psbt.inputs[0].partial_sigs[fake_pub] = b"\xee" * 71
+    real_sig = b"\xaa" * 71
+    psbt.inputs[0].partial_sigs[real_pub] = real_sig
+
+    finalize_simple(psbt, real_pub)
+
+    witness = psbt.inputs[0].final_scriptwitness
+    assert witness.items[0] == real_sig
+    assert witness.items[1] == real_pub.sec()
+
+
+def test_finalize_simple_raises_when_pub_not_signed(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from embit import ec
+    from krux.bip322 import finalize_simple
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    other_pub = next(iter(psbt.inputs[0].bip32_derivations))
+    psbt.inputs[0].partial_sigs[other_pub] = b"\xaa" * 71
+    requested_pub = ec.PrivateKey(b"\x02" * 32).get_public_key()
+    with pytest.raises(ValueError, match="Key not match"):
+        finalize_simple(psbt, requested_pub)
+
+
+def test_check_bip322_psbt_rejects_wrong_vin_count(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    psbt.inputs.append(psbt.inputs[0])
+    assert not check_bip322_psbt(psbt)
+
+
+def test_check_bip322_psbt_rejects_wrong_input_vout(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    psbt.inputs[0].vout = 1
+    assert not check_bip322_psbt(psbt)
+
+
+def test_check_bip322_psbt_rejects_nonzero_output_value(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    psbt.outputs[0].value = 1
+    assert not check_bip322_psbt(psbt)
+
+
+def test_check_bip322_psbt_rejects_non_op_return_output(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from embit.script import Script
+    from krux.bip322 import check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    psbt.outputs[0].script_pubkey = Script(b"\x00\x14" + b"\x00" * 20)
+    assert not check_bip322_psbt(psbt)
+
+
+def test_check_bip322_psbt_rejects_missing_utxo(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    psbt.inputs[0].witness_utxo = None
+    assert not check_bip322_psbt(psbt)
+
+
+def test_check_bip322_psbt_accepts_non_witness_utxo(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux.bip322 import build_bip322_txs, check_bip322_psbt
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2PKH_DERIV, "p2pkh", MESSAGE)
+    spk = psbt.inputs[0].witness_utxo.script_pubkey
+    to_spend, _ = build_bip322_txs(MESSAGE, spk)
+    psbt.inputs[0].witness_utxo = None
+    psbt.inputs[0].non_witness_utxo = to_spend
+    assert check_bip322_psbt(psbt)
+
+
+def test_serialize_bip322_zeros_version_and_sequence(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from krux import bip322
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    bip322.sign(psbt, key)
+    raw = bip322.serialize_bip322(psbt)
+    assert raw[8:12] == b"\x00\x00\x00\x00"
+    seq_pos = 8 + 4 + 1 + 32 + 4 + 1
+    assert raw[seq_pos : seq_pos + 4] == b"\x00\x00\x00\x00"
+
+
+def test_finalize_simple_raises_on_unsupported_script(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from embit.script import Script
+    from embit.transaction import TransactionOutput
+    from krux.bip322 import finalize_simple
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    pub = next(iter(psbt.inputs[0].bip32_derivations))
+    psbt.inputs[0].partial_sigs[pub] = b"\xaa" * 71
+    psbt.inputs[0].witness_utxo = TransactionOutput(
+        value=0,
+        script_pubkey=Script(b"\x51\x20" + b"\x00" * 32),
+    )
+    with pytest.raises(ValueError, match="Unsupported script"):
+        finalize_simple(psbt, pub)
+
+
+def test_sign_skips_wrong_path_same_fingerprint(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from collections import OrderedDict
+    from embit import bip32
+    from embit.psbt import DerivationPath
+    from krux import bip322
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    pub, deriv = next(iter(psbt.inputs[0].bip32_derivations.items()))
+    wrong_path = bip32.parse_path("m/84h/0h/0h/0/1")
+    wrong_pub = key.root.derive(wrong_path).to_public().key
+    wrong_deriv = DerivationPath(key.root.my_fingerprint, wrong_path)
+    psbt.inputs[0].bip32_derivations = OrderedDict(
+        [(wrong_pub, wrong_deriv), (pub, deriv)]
+    )
+
+    bip322.sign(psbt, key)
+
+    assert psbt.inputs[0].final_scriptwitness.items[1] == pub.sec()
+
+
+def test_sign_rejects_wrong_path_same_fingerprint(
+    mocker, m5stickv, tdata, unsigned_bip322_psbt
+):
+    from collections import OrderedDict
+    from embit import bip32
+    from embit.psbt import DerivationPath
+    from krux.bip322 import sign
+
+    key = tdata.SINGLESIG_SIGNING_KEY
+    psbt = unsigned_bip322_psbt(key, P2WPKH_DERIV, "p2wpkh", MESSAGE)
+    wrong_path = bip32.parse_path("m/84h/0h/0h/0/1")
+    wrong_pub = key.root.derive(wrong_path).to_public().key
+    wrong_deriv = DerivationPath(key.root.my_fingerprint, wrong_path)
+    psbt.inputs[0].bip32_derivations = OrderedDict([(wrong_pub, wrong_deriv)])
+    with pytest.raises(ValueError, match="Key not match PSBT"):
+        sign(psbt, key)


### PR DESCRIPTION
### What is this PR for?

This PR implements BIP322 for sign messages for singlesig segwit addresses (P2WPKH, P2TR) and using BIP137 as fallback for P2PKH and P2SH-P2PKH as legacy signed messages, following the usage with Sparrow (the most common coordinator used among users).


### Changes made to:
- [x] Code
- [x] Tests
- [x] Docs
- [x] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on amigo and sparrow (WIP -- not checkout while draft)

### What is the purpose of this pull request?
- [ ] Bug fix
- [x] New feature
- [ ] Docs update
- [ ] Other

# Note to reviewers

This PR is based on #866, so consider this as a WIP since it depends on it. Consider that bip137 commits are temporarily ones just to develop while publicize it.