### PR TITLE
FIX: handle back

### DIFF
--- a/src/krux/pages/datum_tool.py
+++ b/src/krux/pages/datum_tool.py
@@ -366,15 +366,8 @@ class DatumToolMenu(Page):
         """Handler for the 'Read File' menu item"""
         from .utils import Utils
 
-        if not self.has_sd_card():
-            self.flash_error(t("SD card not detected."))
-            return MENU_CONTINUE
-
         utils = Utils(self.ctx)
-        try:
-            filename, contents = utils.load_file(prompt=False)
-        except OSError:
-            pass
+        filename, contents = utils.load_file(prompt=False)
 
         if not contents:
             return MENU_CONTINUE

--- a/src/krux/pages/encryption_ui.py
+++ b/src/krux/pages/encryption_ui.py
@@ -503,7 +503,7 @@ class EncryptionKey(Page):
 
         while True:
             if key in (None, "", b"", ESC_KEY, MENU_CONTINUE):
-                self.flash_error(t("Failed to load"))
+                # user cancelled the keypad or left the QR scanner
                 return None
 
             self.ctx.display.clear()

--- a/src/krux/pages/home_pages/addresses.py
+++ b/src/krux/pages/home_pages/addresses.py
@@ -292,7 +292,9 @@ class Addresses(Page):
 
         qr_capture = QRCodeCapture(self.ctx)
         data, qr_format = qr_capture.qr_capture_loop()
-        if data is None or qr_format != FORMAT_NONE:
+        if data is None:  # user left the QR scanner
+            return MENU_CONTINUE
+        if qr_format != FORMAT_NONE:
             self.flash_error(t("Failed to load"))
             return MENU_CONTINUE
 

--- a/src/krux/pages/home_pages/home.py
+++ b/src/krux/pages/home_pages/home.py
@@ -222,13 +222,15 @@ class Home(Page):
         load_method = self.load_method()
 
         if load_method > LOAD_FROM_SD:
-            return (None, None, "")
+            return None  # user chose Back
 
         if load_method == LOAD_FROM_CAMERA:
             from ..qr_capture import QRCodeCapture
 
             qr_capture = QRCodeCapture(self.ctx)
             data, qr_format = qr_capture.qr_capture_loop()
+            if data is None:
+                return None  # user left the QR scanner
             return (data, qr_format, "")
 
         # If load_method == LOAD_FROM_SD
@@ -241,6 +243,8 @@ class Home(Page):
             prompt=False,
             only_get_filename=True,
         )
+        if not psbt_filename:
+            return None  # user backed out of the SD file browser
         return (None, FORMAT_NONE, psbt_filename)
 
     def _sign_menu(self, signer, psbt_filename, outputs):
@@ -487,12 +491,10 @@ class Home(Page):
             return MENU_CONTINUE
 
         # Load a PSBT
-        data, qr_format, psbt_filename = self.load_psbt()
-
-        if data is None and psbt_filename == "":
-            # Both the camera and the file on SD card failed!
-            self.flash_error(t("Failed to load"))
+        loaded = self.load_psbt()
+        if loaded is None:  # user chose Back on the load menu
             return MENU_CONTINUE
+        data, qr_format, psbt_filename = loaded
 
         # DISABLED to avoid false "Decrypt?" on normal PSBTs as KEF
         # try:

--- a/src/krux/pages/home_pages/sign_message_ui.py
+++ b/src/krux/pages/home_pages/sign_message_ui.py
@@ -62,11 +62,15 @@ class SignMessage(Utils):
 
             qr_capture = QRCodeCapture(self.ctx)
             data, qr_format = qr_capture.qr_capture_loop()
+            if data is None:
+                return None  # user left the QR scanner
             return (data, qr_format, "")
         if load_method == LOAD_FROM_SD:
             message_filename, data = self.load_file(prompt=False)
+            if not message_filename:
+                return None  # user backed out of the SD file browser
             return (data, FORMAT_NONE, message_filename)
-        return (None, None, "")
+        return None  # user chose Back
 
     def _is_valid_derivation_path(self, derivation_path):
         """Strictly checks if the derivation path is valid according to BIP32"""
@@ -368,11 +372,10 @@ class SignMessage(Utils):
 
     def sign_message(self):
         """Sign message user interface"""
-        data, qr_format, message_filename = self._load_message()
-
-        if data is None:
-            self.flash_error(t("Failed to load"))
+        loaded = self._load_message()
+        if loaded is None:  # user chose Back on the load menu
             return MENU_CONTINUE
+        data, qr_format, message_filename = loaded
 
         if message_filename:
             signature_data = self._sign_at_address_from_sd(data)

--- a/src/krux/pages/home_pages/wallet_descriptor.py
+++ b/src/krux/pages/home_pages/wallet_descriptor.py
@@ -133,32 +133,30 @@ class WalletDescriptor(Page):
 
             qr_capture = QRCodeCapture(self.ctx)
             wallet_data, qr_format = qr_capture.qr_capture_loop()
+            if wallet_data is None:
+                return None  # user left the QR scanner
         elif load_method == LOAD_FROM_SD:
             # Try to read the wallet output descriptor from a file on the SD card
             qr_format = FORMAT_NONE
-            try:
-                from ..utils import Utils
+            from ..utils import Utils
 
-                utils = Utils(self.ctx)
-                _, wallet_data = utils.load_file(
-                    (
-                        DESCRIPTOR_FILE_EXTENSION,
-                        JSON_FILE_EXTENSION,
-                    ),
-                    prompt=False,
-                )
-                persisted = True
-            except OSError:
-                pass
+            utils = Utils(self.ctx)
+            filename, wallet_data = utils.load_file(
+                (
+                    DESCRIPTOR_FILE_EXTENSION,
+                    JSON_FILE_EXTENSION,
+                ),
+                prompt=False,
+            )
+            if not filename:
+                # Cancelled, or load_file already reported the failure
+                return None
+            persisted = True
         else:  # Cancel
-            return None, None, False
+            return None
 
         self.ctx.display.clear()
         self.ctx.display.draw_centered_text(t("Processing…"))
-        if wallet_data is None:
-            # Camera or SD card loading failed!
-            self.flash_error(t("Failed to load"))
-            return None, None, False
 
         # Decrypt if needed
         from ..encryption_ui import decrypt_kef
@@ -171,10 +169,10 @@ class WalletDescriptor(Page):
                 wallet_data = wallet_data.decode()
             except:
                 self.flash_error(t("Failed to load"))
-                return None, None, False
+                return None
         except KeyError:
             self.flash_error(t("Failed to decrypt"))
-            return None, None, False
+            return None
         except ValueError:
             # ValueError=not KEF or declined to decrypt
             pass
@@ -322,9 +320,10 @@ class WalletDescriptor(Page):
     def _load_wallet(self):
         """Load a wallet output descriptor from the camera or SD card"""
         # Load wallet data
-        wallet_data, qr_format, persisted = self._load_wallet_data()
-        if wallet_data is None:
+        loaded = self._load_wallet_data()
+        if loaded is None:  # user chose Back, or the load already reported itself
             return MENU_CONTINUE
+        wallet_data, qr_format, persisted = loaded
 
         # Attempt to load the wallet with exception handling
         wallet, wallet_load_exception = self._attempt_wallet_load(

--- a/src/krux/pages/mnemonic_loader.py
+++ b/src/krux/pages/mnemonic_loader.py
@@ -299,8 +299,7 @@ class MnemonicLoader(Page):
         tiny_scanner = TinyScanner(self.ctx, grid_type)
         words = tiny_scanner.scanner(len_mnemonic == 24)
         del tiny_scanner
-        if words is None:
-            self.flash_error(t("Failed to load"))
+        if words is None:  # user left the scanner
             return MENU_CONTINUE
         return self._load_key_from_words(words)
 
@@ -311,8 +310,7 @@ class MnemonicLoader(Page):
 
         qr_capture = QRCodeCapture(self.ctx)
         data, qr_format = qr_capture.qr_capture_loop()
-        if data is None:
-            self.flash_error(t("Failed to load"))
+        if data is None:  # user left the QR scanner
             return MENU_CONTINUE
 
         try:

--- a/src/krux/pages/utils.py
+++ b/src/krux/pages/utils.py
@@ -56,7 +56,13 @@ class Utils(Page):
         """Load a file from SD card"""
         from ..sd_card import SDHandler
 
-        if self.has_sd_card():
+        # Callers read an empty filename as "user cancelled", so every failure
+        # has to report itself here or it would be swallowed silently.
+        if not self.has_sd_card():
+            self.flash_error(t("SD card not detected."))
+            return "", None
+
+        try:
             with SDHandler() as sd:
                 self.ctx.display.clear()
                 if not prompt or self.prompt(
@@ -75,6 +81,8 @@ class Utils(Page):
                         if only_get_filename:
                             return filename, None
                         return filename, sd.read_binary(filename)
+        except OSError:
+            self.flash_error(t("Failed to load"))
         return "", None
 
     @staticmethod

--- a/src/krux/pages/wallet_settings.py
+++ b/src/krux/pages/wallet_settings.py
@@ -143,8 +143,7 @@ class PassphraseEditor(Page):
 
         qr_capture = QRCodeCapture(self.ctx)
         data, _ = qr_capture.qr_capture_loop()
-        if data is None:
-            self.flash_error(t("Failed to load"))
+        if data is None:  # user left the QR scanner
             return MENU_CONTINUE
 
         try:

--- a/tests/pages/__init__.py
+++ b/tests/pages/__init__.py
@@ -30,3 +30,11 @@ def create_ctx(mocker, btn_seq, wallet=None, printer=None, touch_seq=None):
             current_index=mocker.MagicMock(side_effect=touch_seq)
         )
     return ctx
+
+
+def assert_not_flashed(ctx, text):
+    """Asserts `text` was never flashed on the mocked display"""
+    assert not any(
+        call.args and call.args[0] == text
+        for call in ctx.display.flash_text.call_args_list
+    ), ("unexpected flash: %s" % text)

--- a/tests/pages/home_pages/test_addresses.py
+++ b/tests/pages/home_pages/test_addresses.py
@@ -1,4 +1,5 @@
 import pytest
+from .. import assert_not_flashed
 from .test_home import tdata, create_ctx
 
 # fortdata.SINGLESIG_ACTION_KEY_TEST_P2WPKH
@@ -1179,3 +1180,40 @@ def test_list_change_addresses(mocker, m5stickv, tdata):
 
         # assert the number of calls to wait_for_button
         assert ctx.input.wait_for_button.call_count == len(sequence_buttons)
+
+
+def test_scan_address_camera_back_is_silent(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.addresses import Addresses
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.wallet import Wallet
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, [], wallet, None)
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert Addresses(ctx).scan_address() == MENU_CONTINUE
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
+
+
+def test_scan_address_wrong_qr_format_still_fails(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.addresses import Addresses
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.qr import FORMAT_PMOFN
+    from krux.wallet import Wallet
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, [], wallet, None)
+    mocker.patch.object(
+        QRCodeCapture, "qr_capture_loop", new=lambda self: ("an address", FORMAT_PMOFN)
+    )
+
+    assert Addresses(ctx).scan_address() == MENU_CONTINUE
+
+    assert any(
+        c.args[0] == "Failed to load" for c in ctx.display.flash_text.call_args_list
+    )

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -1,6 +1,6 @@
 import pytest
 from ...shared_mocks import MockPrinter
-from .. import create_ctx
+from .. import create_ctx, assert_not_flashed
 from ...test_psbt import tdata as psbt_tdata
 
 
@@ -654,6 +654,9 @@ def test_load_sign_message_menu(mocker, amigo):
 
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
+
 
 def test_load_sign_psbt_menu(mocker, amigo, tdata):
     from krux.pages.home_pages.home import Home
@@ -682,6 +685,9 @@ def test_load_sign_psbt_menu(mocker, amigo, tdata):
 
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
 
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
+
     # assert that some methods where called, but not all
     for _method in [
         ("_pre_load_psbt_warn", "assert_called_once"),
@@ -693,6 +699,33 @@ def test_load_sign_psbt_menu(mocker, amigo, tdata):
     ]:
         home_method = getattr(home, _method[0])
         getattr(home_method, _method[1])()
+
+
+def test_load_sign_psbt_sd_back_is_silent(mocker, amigo, tdata):
+    from krux.pages.home_pages.home import Home
+    from krux.pages import MENU_CONTINUE
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+
+    BTN_SEQUENCE = [
+        BUTTON_PAGE,  # Go to "Load from SD card"
+        BUTTON_ENTER,  # Select "Load from SD card"
+    ]
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, BTN_SEQUENCE, wallet)
+    home = Home(ctx)
+    mocker.patch.object(home, "has_sd_card", new=lambda: True)
+    mock_utils = mocker.patch("krux.pages.utils.Utils")
+    # user backed out of the SD file browser
+    mock_utils.return_value.load_file.return_value = ("", None)
+
+    assert home.sign_psbt() == MENU_CONTINUE
+
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
 
 
 def DISABLEDtest_sign_psbt_fails_on_decrypt_kef_key_error(mocker, m5stickv, tdata):
@@ -1951,3 +1984,25 @@ def test_unverified_amounts_warning(mocker, m5stickv):
     mocker.spy(ctx.display, "draw_centered_text")
     assert home._unverified_amounts_psbt_warn(FakeSigner(False)) is True
     assert ctx.display.draw_centered_text.call_count == 0
+
+
+def test_load_sign_psbt_camera_back_is_silent(mocker, amigo, tdata):
+    from krux.pages.home_pages.home import Home
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+
+    BTN_SEQUENCE = [BUTTON_ENTER]  # Select "Load from camera"
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, BTN_SEQUENCE, wallet)
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert Home(ctx).sign_psbt() == MENU_CONTINUE
+
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")

--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -1,5 +1,5 @@
 from ...shared_mocks import MockPrinter, get_mock_open
-from .. import create_ctx
+from .. import create_ctx, assert_not_flashed
 from .test_home import tdata
 
 
@@ -595,3 +595,49 @@ def test_load_from_sd_card(mocker, m5stickv, tdata):
     sign_msg._export_to_qr.assert_called()
 
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+
+def test_sign_message_sd_back_is_silent(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.pages import MENU_CONTINUE
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+
+    btn_seq = [
+        BUTTON_PAGE,  # Go to "Load from SD card"
+        BUTTON_ENTER,  # Select "Load from SD card"
+    ]
+
+    wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+    ctx = create_ctx(mocker, btn_seq, wallet)
+    sign_msg = SignMessage(ctx)
+    mocker.patch.object(sign_msg, "has_sd_card", new=lambda: True)
+    # user backed out of the SD file browser
+    mocker.patch.object(sign_msg, "load_file", return_value=("", None))
+
+    assert sign_msg.sign_message() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
+
+
+def test_sign_message_camera_back_is_silent(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.sign_message_ui import SignMessage
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+
+    btn_seq = [BUTTON_ENTER]  # Select "Load from camera"
+
+    wallet = Wallet(tdata.SINGLESIG_SIGNING_KEY)
+    ctx = create_ctx(mocker, btn_seq, wallet)
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert SignMessage(ctx).sign_message() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")

--- a/tests/pages/home_pages/test_wallet_descriptor.py
+++ b/tests/pages/home_pages/test_wallet_descriptor.py
@@ -1,6 +1,7 @@
 import pytest
 from ...shared_mocks import MockPrinter
-from .test_home import tdata, create_ctx
+from .. import create_ctx, assert_not_flashed
+from .test_home import tdata
 from ...test_wallet import tdata as wallet_tdata
 
 
@@ -115,7 +116,10 @@ def test_wallet(mocker, m5stickv, tdata):
         # Mock SD card descriptor loading
         if case[4][:3] == [BUTTON_ENTER, BUTTON_PAGE, BUTTON_ENTER]:
             mock_utils = mocker.patch("krux.pages.utils.Utils")
-            mock_utils.return_value.load_file.return_value = (None, case[2])
+            mock_utils.return_value.load_file.return_value = (
+                "descriptor.txt",
+                case[2],
+            )
 
         wallet_descriptor.wallet()
 
@@ -136,6 +140,33 @@ def test_wallet(mocker, m5stickv, tdata):
                     wallet_descriptor.display_loading_wallet.assert_called_once()
                     assert ctx.wallet.has_change_addr()
         assert ctx.input.wait_for_button.call_count == len(case[4])
+
+
+def test_wallet_load_sd_back_is_silent(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.wallet_descriptor import WalletDescriptor
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.pages import MENU_CONTINUE
+
+    btn_seq = [
+        BUTTON_ENTER,  # confirm load
+        BUTTON_PAGE,  # go to "Load from SD card"
+        BUTTON_ENTER,  # select "Load from SD card"
+    ]
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, btn_seq, wallet)
+    wallet_descriptor = WalletDescriptor(ctx)
+    mocker.patch.object(wallet_descriptor, "has_sd_card", return_value=True)
+    mock_utils = mocker.patch("krux.pages.utils.Utils")
+    # user backed out of the SD file browser
+    mock_utils.return_value.load_file.return_value = ("", None)
+
+    assert wallet_descriptor.wallet() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
 
 
 def test_wallet_load_fails_on_decrypt_kef_key_error(mocker, m5stickv, tdata):
@@ -920,3 +951,27 @@ def test_combined_policy_and_network_mismatch_accept(mocker, m5stickv, tdata):
     # Verify wallet was loaded
     assert ctx.wallet.is_loaded()
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+
+def test_wallet_load_camera_back_is_silent(mocker, m5stickv, tdata):
+    from krux.pages.home_pages.wallet_descriptor import WalletDescriptor
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+    from krux.wallet import Wallet
+    from krux.input import BUTTON_ENTER
+
+    btn_seq = [
+        BUTTON_ENTER,  # confirm load
+        BUTTON_ENTER,  # select "Load from camera"
+    ]
+
+    wallet = Wallet(tdata.SINGLESIG_12_WORD_KEY)
+    ctx = create_ctx(mocker, btn_seq, wallet)
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert WalletDescriptor(ctx).wallet() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(btn_seq)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from . import create_ctx
+from . import create_ctx, assert_not_flashed
 
 TEST_KEY = "test key"
 CBC_WORDS = "dog guitar hotel random owner gadget salute riot patrol work advice panic erode leader pass cross section laundry elder asset soul scale immune scatter"
@@ -1898,3 +1898,23 @@ def test_kefenvelope_unseal_ui(m5stickv, mocker):
     with pytest.raises(KeyError, match="Failed to decrypt"):
         page.unseal_ui()
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
+def test_encryption_key_camera_back_is_silent(m5stickv, mocker):
+    from krux.pages.encryption_ui import EncryptionKey
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+    from krux.pages.qr_capture import QRCodeCapture
+
+    BTN_SEQUENCE = [
+        BUTTON_PAGE,  # move to QR code key
+        BUTTON_ENTER,  # choose QR code key
+    ]
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert EncryptionKey(ctx).encryption_key() is None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")

--- a/tests/pages/test_login.py
+++ b/tests/pages/test_login.py
@@ -1,5 +1,5 @@
 import pytest
-from . import create_ctx
+from . import create_ctx, assert_not_flashed
 
 
 @pytest.fixture
@@ -1907,3 +1907,41 @@ def test_load_default_wallet(mocker, amigo):
         assert ctx.wallet.key.policy_type == case[3]
         assert ctx.wallet.key.script_type == case[4]
         assert ctx.wallet.key.derivation == case[5]
+
+
+def test_load_key_from_qr_code_camera_back_is_silent(m5stickv, mocker):
+    from krux.pages.login import Login
+    from krux.pages import MENU_CONTINUE
+    from krux.pages.qr_capture import QRCodeCapture
+
+    ctx = create_ctx(mocker, [])
+    # user left the QR scanner without scanning anything
+    mocker.patch.object(QRCodeCapture, "qr_capture_loop", new=lambda self: (None, None))
+
+    assert Login(ctx).load_key_from_qr_code() == MENU_CONTINUE
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
+
+
+def test_load_key_from_tiny_seed_image_back_is_silent(m5stickv, mocker):
+    from krux.pages.login import Login
+    from krux.pages import MENU_CONTINUE
+    from krux.input import BUTTON_ENTER
+
+    BTN_SEQUENCE = [
+        BUTTON_ENTER,  # 12 words
+        BUTTON_ENTER,  # Proceed?
+    ]
+    # user left the scanner without capturing a seed
+    mocker.patch(
+        "krux.pages.tiny_seed.TinyScanner.scanner",
+        new=mocker.MagicMock(return_value=None),
+    )
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+
+    assert Login(ctx).load_key_from_tiny_seed_image() == MENU_CONTINUE
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")

--- a/tests/pages/test_utils.py
+++ b/tests/pages/test_utils.py
@@ -49,3 +49,29 @@ def test_load_file_with_no_sd(m5stickv, mocker):
 
     assert file_name == ""
     assert data is None
+    # an empty filename means "cancelled" to callers, so a missing card must
+    # report itself here instead of failing silently
+    ctx.display.flash_text.assert_called_once()
+    assert ctx.display.flash_text.call_args.args[0] == "SD card not detected."
+
+
+def test_load_file_with_sd_read_error(m5stickv, mocker):
+    from krux.pages.utils import Utils
+
+    mocker.patch(
+        "krux.sd_card.SDHandler.dir_exists",
+        mocker.MagicMock(return_value=True),
+    )
+    mocker.patch(
+        # first entry is has_sd_card()'s hot-plug probe, second is load_file's
+        "krux.sd_card.SDHandler.__enter__",
+        mocker.MagicMock(side_effect=[None, OSError]),
+    )
+    ctx = create_ctx(mocker, None)
+    utils = Utils(ctx)
+    file_name, data = utils.load_file(prompt=False)
+
+    assert file_name == ""
+    assert data is None
+    # same rule: a read that blew up must report itself, not look like a cancel
+    assert ctx.display.flash_text.call_args.args[0] == "Failed to load"

--- a/tests/pages/test_wallet_settings.py
+++ b/tests/pages/test_wallet_settings.py
@@ -1,4 +1,4 @@
-from . import create_ctx
+from . import create_ctx, assert_not_flashed
 from .home_pages.test_home import tdata
 import pytest
 
@@ -77,7 +77,7 @@ def test_qr_passphrase_too_long(m5stickv, mocker):
         qr_capturer.assert_called_once()
 
 
-def test_qr_passphrase_fail(m5stickv, mocker):
+def test_qr_passphrase_camera_back_is_silent(m5stickv, mocker):
     from krux.pages.wallet_settings import PassphraseEditor, MENU_CONTINUE
     from krux.pages.qr_capture import QRCodeCapture
 
@@ -91,6 +91,9 @@ def test_qr_passphrase_fail(m5stickv, mocker):
 
     assert test_passphrase == MENU_CONTINUE
     qr_capturer.assert_called_once()
+
+    # "Back" is not a failure - it must not flash an error
+    assert_not_flashed(ctx, "Failed to load")
 
 
 def test_qr_passphrase_fails_on_decrypt_kef_key_error(mocker, m5stickv, tdata):


### PR DESCRIPTION
### What is this PR for?
GOING BACK SHOULD NOT BE A FAILURE. this pr fixes that across the sd file browser and the qr scanner.

backing out of the load-method menu already returned silently, but backing out of the deeper sd-card file picker fell through to the "failed to load" error. utils.load_file() returns ("", None) for both user cancellation and a real load failure, so the load flows now treat an empty filename as a user cancellation.

the qr scanner had the same bug. qr_capture_loop() returns (None, None) only when the user leaves the scanner, never on a decode failure, so leaving the camera flashed the same false error. that half is fixed the same way.

this is covered for:

load_psbt()
_load_message()
_load_wallet_data()

### why load_file() now reports its own errors
reading an empty filename as "cancelled" at the call site only works if a real failure never looks the same. it did. load_file() also returned ("", None) when there was no sd card, so pulling the card after the load menu was drawn turned a real failure into a silent no-op instead of an error. has_sd_card() is a live hot-plug check and the load menu only runs it once, when it is built.

so rather than adding a cancel check at each call site, load_file() now reports its own failures. "sd card not detected." for a missing card, "failed to load" for an oserror during the read. an empty filename then means one thing everywhere: nothing was loaded, and the user has already been told why.

### when "failed to load" should actually show up
it should mean we got something and it was unusable. an i/o error reading the card, or bytes that would not decode. it should never mean the user pressed back.

once both halves report themselves, three of the old guards are unreachable and are removed:

sign_psbt() and sign_message() — the camera path returns early, the sd path returns early, and read_binary() never returns None
_load_wallet_data() — same, plus the `except OSError: pass` that load_file() now owns

the guard that stays is the one on wallet_data.decode(), which is the real case: a file that loaded fine but is not text.

datum_tool.read_file() had that same `except OSError: pass` and then read the unbound `contents`, raising NameError instead of showing an sd error. load_file() owns that path now, so the swallow is gone.

### to reproduce
go to sign → message → back, or back out from the sd-card file picker or the qr scanner while loading a psbt, message, or wallet.

for the failure side, pull the sd card after the load menu is drawn but before picking a file.

### Changes made to:
- [X] Code
- [X] Tests

### Did you build the code and tested on device?
- [X] Yes, build and tested on Maixpy Amigo

### What is the purpose of this pull request?
- [X] Bug fix
