### PR TITLE
docs: fix the freeze state of the uv auto updating libs when sync.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ __pycache__/
 *.pyc
 *.egg-info
 
+# uv virtual environment (do NOT ignore uv.lock, it must be committed)
+######################
+.venv/
+
 # Customized Makefile/project overrides
 ######################
 GNUmakefile

--- a/README.md
+++ b/README.md
@@ -68,20 +68,20 @@ The first time, the build can take around an hour or so to complete. Subsequent 
 ## Install Krux and dev tools
 Krux uses [uv](https://docs.astral.sh/uv/) for Python packaging and environment management. Install uv by following its [installation guide](https://docs.astral.sh/uv/getting-started/installation/), then sync the project to install runtime deps ([embit](https://github.com/diybitcoinhardware/embit) and [uUR](https://github.com/selfcustody/cUR), the native UR module compiled from the same sources the devices run) along with the `dev` group ([pytest](https://docs.pytest.org), [pylint](https://pypi.org/project/pylint/), [black](https://github.com/psf/black) and i18n helpers):
 ```bash
-uv sync
+uv sync --frozen
 ```
 
-> **`uUR` is a C extension** It is built from the `bc-ur` submodule nested under `firmware/MaixPy`, so clone with `--recursive` (or run `git submodule update --init --recursive`) and make sure a C compiler and the Python development headers are installed (`python3-dev` on Debian/Ubuntu). After changing the submodule, rebuild it with `uv sync --reinstall-package uUR`.
+> **`uUR` is a C extension** It is built from the `bc-ur` submodule nested under `firmware/MaixPy`, so clone with `--recursive` (or run `git submodule update --init --recursive`) and make sure a C compiler and the Python development headers are installed (`python3-dev` on Debian/Ubuntu). After changing the submodule, rebuild it with `uv sync --frozen --reinstall-package uUR`.
 
-`uv sync` creates a `.venv` in the project root, resolves `uv.lock` if needed, and installs everything — this is the day-to-day command. When dependencies in `pyproject.toml` change but you only want to refresh `uv.lock` without touching the venv, run `uv lock` instead; `uv sync` will then pick the new pins on its next run.
+`uv sync --frozen` creates a `.venv` in the project root and installs exactly what `uv.lock` pins **without re-resolving** — this is the day-to-day command and it matches what CI runs, so your local dependency versions stay reproducible. When dependencies in `pyproject.toml` change and you want to refresh the pins, run `uv lock` (updates `uv.lock` only) followed by `uv sync` (without `--frozen`, so it applies the new pins to the venv).
 
-> **CI uses `uv sync --frozen`** The workflows refuse to silently re-resolve when `uv.lock` drifts (we value a lot reproducible builds). Whenever you edit `pyproject.toml` (add, remove, or bump a dependency), run `uv lock` (or `uv sync`) and commit `uv.lock` (in same change). Otherwise CI will fail.
+> **CI uses `uv sync --frozen`** The workflows refuse to silently re-resolve when `uv.lock` drifts (we value reproducible builds a lot). Whenever you edit `pyproject.toml` (add, remove, or bump a dependency), run `uv lock` (or `uv sync` without `--frozen`) and commit `uv.lock` in the same change. Otherwise CI will fail.
 
 ### Migrating from a previous Poetry clone
 If your clone was set up with Poetry, remove the old environment before the first `uv sync` so the two managers do not shadow each other:
 ```bash
 rm -rf .venv poetry.lock
-uv sync
+uv sync --frozen
 ```
 
 ## Format code
@@ -141,10 +141,10 @@ This is useful for rapid code development that utilizes UI/UX. It is also good f
 Before executing, make sure you have synced the simulator extras:
 ```bash
 # This cmd installs the simulator extras alongside the dev group
-uv sync --extra simulator
+uv sync --frozen --extra simulator
 
 # To install all extras, use:
-uv sync --all-extras
+uv sync --frozen --all-extras
 ```
 
 Run the simulator:
@@ -280,10 +280,10 @@ Before change documentation, and run the mkdocs server, make sure you have synce
 
 ```bash
 # This cmd installs the docs extras alongside the dev group
-uv sync --extra docs
+uv sync --frozen --extra docs
 
 # To install all extras, use:
-uv sync --all-extras
+uv sync --frozen --all-extras
 ```
 
 To change lateral and upper menus on documentation, see `mkdocs.yml` file on `nav` section. To create or edit translations (TODO: need help!), read [here](i18n/README.md).


### PR DESCRIPTION
reference change in krux-installer:
https://github.com/selfcustody/krux-installer/pull/296

### What is this PR for?
Adds to the .gitignore the auto generated .venv directoty from the uv setup, and add to the documentation the --frozen flag to take the version of the dependencies from the uv.lock and pyproject.toml without trying to update then just like this PR in krux-installer: https://github.com/selfcustody/krux-installer/pull/296


### Changes made to:
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [x] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Other
