### PR TITLE
feat: add Via Entropy App 2XD8 mnemonic path

### DIFF
--- a/simulator/sequences/entropy-app-2xd8-demo-amigo.txt
+++ b/simulator/sequences/entropy-app-2xd8-demo-amigo.txt
@@ -1,0 +1,23 @@
+include _wait-for-logo.txt
+
+# Navigate to New Mnemonic > Via Entropy App 2XD8
+press BUTTON_B
+press BUTTON_A
+x4 press BUTTON_B
+press BUTTON_A
+
+# 12 words, then Proceed
+press BUTTON_A
+press BUTTON_A
+
+screenshot amigo-entropy-app-2xd8-wheel-start.png
+
+# Dial White up to 5, lock; Black stays default and locks
+x4 press BUTTON_B
+press BUTTON_A
+
+screenshot amigo-entropy-app-2xd8-white-locked.png
+
+press BUTTON_A
+
+screenshot amigo-entropy-app-2xd8-card-revealed.png

--- a/simulator/sequences/entropy-app-2xd8-demo.txt
+++ b/simulator/sequences/entropy-app-2xd8-demo.txt
@@ -1,0 +1,146 @@
+include _wait-for-logo.txt
+
+# Navigate to New Mnemonic > Via Entropy App 2XD8
+press BUTTON_B
+press BUTTON_A
+x4 press BUTTON_B
+press BUTTON_A
+
+# 12 words, then Proceed
+press BUTTON_A
+press BUTTON_A
+
+screenshot entropy-app-2xd8-card-wheel-start.png
+
+press BUTTON_A
+
+screenshot entropy-app-2xd8-white-locked-black-active.png
+
+x1 press BUTTON_B
+press BUTTON_A
+
+screenshot entropy-app-2xd8-card-revealed-next-screen.png
+
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+screenshot entropy-app-2xd8-word-1-reveal.png
+
+press BUTTON_A
+
+x4 press BUTTON_B
+press BUTTON_A
+x5 press BUTTON_B
+press BUTTON_A
+x6 press BUTTON_B
+press BUTTON_A
+x7 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+press BUTTON_A
+x1 press BUTTON_B
+press BUTTON_A
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+x4 press BUTTON_B
+press BUTTON_A
+x5 press BUTTON_B
+press BUTTON_A
+x6 press BUTTON_B
+press BUTTON_A
+x7 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+press BUTTON_A
+x1 press BUTTON_B
+press BUTTON_A
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+x4 press BUTTON_B
+press BUTTON_A
+x5 press BUTTON_B
+press BUTTON_A
+x6 press BUTTON_B
+press BUTTON_A
+x7 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+press BUTTON_A
+x1 press BUTTON_B
+press BUTTON_A
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+x4 press BUTTON_B
+press BUTTON_A
+x5 press BUTTON_B
+press BUTTON_A
+x6 press BUTTON_B
+press BUTTON_A
+x7 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+press BUTTON_A
+x1 press BUTTON_B
+press BUTTON_A
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+x4 press BUTTON_B
+press BUTTON_A
+x5 press BUTTON_B
+press BUTTON_A
+x6 press BUTTON_B
+press BUTTON_A
+x7 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+press BUTTON_A
+x1 press BUTTON_B
+press BUTTON_A
+x2 press BUTTON_B
+press BUTTON_A
+x3 press BUTTON_B
+press BUTTON_A
+
+press BUTTON_A
+
+screenshot entropy-app-2xd8-all-words-drawn.png
+
+# dismiss the Words Drawn list (new: it's now its own screen)
+press BUTTON_A
+
+
+press BUTTON_A
+
+screenshot entropy-app-2xd8-mnemonic-confirm.png

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -95,12 +95,27 @@ class Login(MnemonicLoader):
                 (t("Via Words"), lambda: self.load_key_from_text(new=True)),
                 (t("Via D6"), self.new_key_from_dice),
                 (t("Via D20"), lambda: self.new_key_from_dice(True)),
+                (t("Via Entropy App 2XD8"), self.new_key_from_entropy_app_2xd8),
             ],
         )
         index, status = submenu.run_loop()
         if index == submenu.back_index:
             return MENU_CONTINUE
         return status
+
+
+    def new_key_from_entropy_app_2xd8(self):
+        """Handler for 'new mnemonic'>'via Entropy App 2XD8' menu item"""
+        from .new_mnemonic.entropy_app_2xd8 import EntropyApp2XD8
+
+        entropy_app_2xd8 = EntropyApp2XD8(self.ctx)
+        captured_entropy = entropy_app_2xd8.new_key()
+        if captured_entropy is not None:
+            from embit.bip39 import mnemonic_from_bytes
+
+            words = mnemonic_from_bytes(captured_entropy).split()
+            return self._load_key_from_words(words, new=True)
+        return MENU_CONTINUE
 
     def new_key_from_dice(self, d_20=False):
         """Handler for both 'new mnemonic'>'via D6/D20' menu items. Default is D6"""

--- a/src/krux/pages/new_mnemonic/entropy_app_2xd8.py
+++ b/src/krux/pages/new_mnemonic/entropy_app_2xd8.py
@@ -1,0 +1,284 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2021-2024 Krux contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+2XD8 Entropy Booklet method (github.com/bowtiedcrake/2xd8-entropy-booklet).
+
+Unlike Krux's D6/D20 dice entropy (which hashes a whole roll sequence with
+SHA-256), this method draws *whole BIP39 words* directly: two distinguishable
+D8 dice are rolled twice per word.
+
+  Roll 1 (card select): White read openly 1-8 (3 bits). Black read only as a
+  pair -- 1/2, 3/4, 5/6, 7/8 (2 bits). Together they select 1 of 32 "cards".
+  Roll 2 (word select): White = row 1-8, Black = column 1-8 on that card's
+  8x8 grid (6 bits).
+
+5 + 6 = 11 bits = 1-of-2048, exactly the width of one BIP39 word index, with
+no modulo bias -- the same mapping used by the printed booklet (card n, cell
+k holds BIP39 index n + 32*k).
+
+Each roll pair is entered on a two-wheel picker (White, Black) and the result
+-- the card number, then the word -- is revealed the instant it's computed,
+so a user can check it against a physical printed booklet as they go, word
+by word, instead of only seeing results after the whole mnemonic is drawn.
+
+The final checksum word is never drawn by hand: the (11 or 23) drawn words
+supply the leading entropy bits, the remaining bits are zero-padded, and
+embit's mnemonic_from_bytes() (standard BIP39, called by the Login handler)
+computes the real checksum word from that entropy -- mirroring the booklet's
+own rule that a hardware wallet/offline tool must compute the last word.
+"""
+import lcd
+from embit.bip39 import WORDLIST
+from .. import (
+    Page,
+    ESC_KEY,
+    BUTTON_ENTER,
+    BUTTON_PAGE,
+    BUTTON_PAGE_PREV,
+    BUTTON_TOUCH,
+    SWIPE_UP,
+    SWIPE_DOWN,
+    SWIPE_LEFT,
+    FAST_FORWARD,
+    FAST_BACKWARD,
+)
+from ...display import DEFAULT_PADDING, FONT_HEIGHT, FONT_WIDTH, BOTTOM_PROMPT_LINE
+from ...themes import theme
+from ...krux_settings import t
+from ...kboard import kboard
+
+INCREMENT = (BUTTON_PAGE, SWIPE_DOWN, FAST_FORWARD)
+DECREMENT = (BUTTON_PAGE_PREV, SWIPE_UP, FAST_BACKWARD)
+LOCK_IN = (BUTTON_ENTER, BUTTON_TOUCH)
+
+
+def card_number(white1, black1):
+    """White's 8 values x Black collapsed into 4 equal pairs -> 1-of-32 card"""
+    black_pair_idx = (black1 + 1) // 2  # 1,2->1  3,4->2  5,6->3  7,8->4
+    return (white1 - 1) * 4 + black_pair_idx
+
+
+def word_index(card_n, white2, black2):
+    """Full 1-based BIP39 index (1..2048), same mapping as the printed
+    booklet: card n, cell k (row-major, White=row, Black=col) holds
+    index n + 32*k."""
+    k = (white2 - 1) * 8 + (black2 - 1)  # 0..63
+    return card_n + 32 * k
+
+
+class EntropyApp2XD8(Page):
+    """Draw whole BIP39 words with a pair of D8 dice, 2XD8 Booklet method.
+
+    Each word is drawn in two revealed steps -- card, then word -- via a
+    two-wheel (White, Black) picker, so the result can be checked against a
+    physical booklet as it's produced.
+    """
+
+    def __init__(self, ctx):
+        super().__init__(ctx, None)
+        self.ctx = ctx
+        self.words_needed = 0
+        self.words = []
+
+    def _draw_wheel_screen(self, top_label, sub_label, values, active, locked):
+        self.ctx.display.clear()
+        self.ctx.display.draw_hcentered_text(top_label, color=theme.highlight_color)
+        self.ctx.display.draw_hcentered_text(sub_label, 2 * FONT_HEIGHT)
+
+        width = self.ctx.display.width()
+        height = self.ctx.display.height()
+        col_w = width // 2
+        box_size = min(col_w - 3 * FONT_WIDTH, height // 4)
+        box_y = height * 3 // 5 - box_size // 2
+
+        labels = (t("WHITE"), t("BLACK"))
+        for i in range(2):
+            cx = col_w * i + col_w // 2
+            label_color = theme.highlight_color if i == active else theme.fg_color
+            self.ctx.display.draw_string(
+                cx - len(labels[i]) * FONT_WIDTH // 2,
+                box_y - 2 * FONT_HEIGHT,
+                labels[i],
+                label_color,
+            )
+            box_x = cx - box_size // 2
+            if i == active:
+                self.ctx.display.outline(
+                    box_x, box_y, box_size, box_size, theme.highlight_color
+                )
+            text = str(values[i])
+            value_color = theme.highlight_color if locked[i] else theme.fg_color
+            self.ctx.display.draw_string(
+                cx - len(text) * FONT_WIDTH // 2,
+                box_y + box_size // 2 - FONT_HEIGHT // 2,
+                text,
+                value_color,
+            )
+
+        # Skipped on tiny displays (m5stickv/cube) -- there isn't room for
+        # this without recreating the exact cramped-screen problem this
+        # feature is meant to avoid; the header's "Word X of N" is the only
+        # progress context those devices get.
+        if not kboard.has_minimal_display:
+            self._draw_recent_words(height)
+            self._draw_progress_bar(height)
+
+    def _draw_recent_words(self, height):
+        if not self.words:
+            return
+        # Drop the oldest of the 3 first if it still doesn't fit -- better to
+        # show fewer words cleanly than wrap into the progress bar below.
+        recent = self.words[-3:]
+        start_num = len(self.words) - len(recent) + 1
+        while recent:
+            text = " ".join(
+                "%d.%s" % (start_num + i, w) for i, w in enumerate(recent)
+            )
+            if lcd.string_width_px(text) <= self.ctx.display.usable_width():
+                break
+            recent = recent[1:]
+            start_num += 1
+        if not text:
+            return
+        self.ctx.display.draw_hcentered_text(
+            text, height - 3 * FONT_HEIGHT, theme.fg_color, max_lines=1
+        )
+
+    def _draw_progress_bar(self, height):
+        offset_y = height - int(1.5 * FONT_HEIGHT)
+        pb_height = FONT_HEIGHT - 4
+        words_done = len(self.words)
+        if words_done and self.words_needed:
+            progress = words_done * (self.ctx.display.usable_width() - 3)
+            progress //= self.words_needed
+            self.ctx.display.fill_rectangle(
+                DEFAULT_PADDING + 2,
+                offset_y + 2,
+                progress,
+                pb_height - 4,
+                theme.fg_color,
+            )
+        outline_color = (
+            theme.go_color if words_done >= self.words_needed else theme.no_esc_color
+        )
+        self.ctx.display.outline(
+            DEFAULT_PADDING,
+            offset_y,
+            self.ctx.display.usable_width(),
+            pb_height,
+            outline_color,
+        )
+
+    def _pick_die_pair(self, top_label, sub_label):
+        """Two-wheel picker (White, Black), 1-8 each. Page/swipe up-down
+        scrolls the active wheel; Enter/tap locks it and auto-advances to
+        the next wheel; a long-press/swipe-left cancels. Returns
+        (white, black) ints, or None if cancelled."""
+        values = [1, 1]
+        locked = [False, False]
+        active = 0
+        while True:
+            self._draw_wheel_screen(top_label, sub_label, values, active, locked)
+            btn = self.ctx.input.wait_for_button()
+            if btn in INCREMENT:
+                values[active] = values[active] % 8 + 1
+            elif btn in DECREMENT:
+                values[active] = (values[active] - 2) % 8 + 1
+            elif btn in LOCK_IN:
+                locked[active] = True
+                if active == 0:
+                    active = 1
+                else:
+                    return values[0], values[1]
+            elif btn == SWIPE_LEFT:
+                if self.esc_prompt() == ESC_KEY:
+                    return None
+
+    def new_key(self):
+        """Draw words via the 2XD8 method; returns raw entropy bytes (drawn
+        words zero-padded to the full width) ready for
+        embit.bip39.mnemonic_from_bytes, or None if cancelled."""
+        len_mnemonic = self.choose_len_mnemonic()
+        if not len_mnemonic:
+            return None
+        self.words_needed = 11 if len_mnemonic == 12 else 23
+
+        self.ctx.display.draw_hcentered_text(
+            t("Roll two D8 dice (White, Black), twice per word.")
+            + "\n"
+            + t("Card, then word, is revealed as you go --")
+            + "\n"
+            + t("check them against your booklet.")
+        )
+        if not self.prompt(t("Proceed?"), BOTTOM_PROMPT_LINE):
+            return None
+
+        while len(self.words) < self.words_needed:
+            word_num = len(self.words) + 1
+            top_label = t("Word %d of %d") % (word_num, self.words_needed)
+
+            rolled = self._pick_die_pair(top_label, t("Get Card"))
+            if rolled is None:
+                return None
+            card_n = card_number(*rolled)
+
+            rolled = self._pick_die_pair(top_label, t("Card %02d - Get Word") % card_n)
+            if rolled is None:
+                return None
+            word = WORDLIST[word_index(card_n, *rolled) - 1]
+
+            self.words.append(word)
+            self.ctx.display.clear()
+            self.ctx.display.draw_centered_text(
+                t("WORD %d: %s") % (word_num, word.upper())
+            )
+            self.ctx.display.draw_hcentered_text(
+                t("Press to continue"), BOTTOM_PROMPT_LINE, theme.frame_color
+            )
+            while True:
+                btn = self.ctx.input.wait_for_button()
+                if btn in LOCK_IN:
+                    break
+                if btn == SWIPE_LEFT:
+                    if self.esc_prompt() == ESC_KEY:
+                        return None
+
+        # Reuses the same numbered-list renderer the final mnemonic screen
+        # uses (paginates by button-press on tiny displays, two columns on
+        # bigger ones) instead of cramming everything into one info box.
+        # The prompt is deliberately a separate, cleared screen -- chaining
+        # it directly under the word list at a fixed offset overlapped the
+        # last word(s) on small displays, since display_mnemonic() doesn't
+        # report how many lines it actually used.
+        self.display_mnemonic(" ".join(self.words), title=t("Words Drawn"))
+        self.ctx.input.wait_for_button()
+        self.ctx.display.clear()
+        if not self.prompt(
+            t("Compute checksum word and generate mnemonic?"),
+            self.ctx.display.height() // 2,
+        ):
+            return None
+
+        bits = "".join("{:011b}".format(WORDLIST.index(word)) for word in self.words)
+        total_bits = 256 if len_mnemonic == 24 else 128
+        bits += "0" * (total_bits - len(bits))  # unresolved tail bits, per booklet spec
+        return int(bits, 2).to_bytes(total_bits // 8, "big")

--- a/tests/pages/new_mnemonic/test_entropy_app_2xd8.py
+++ b/tests/pages/new_mnemonic/test_entropy_app_2xd8.py
@@ -1,0 +1,127 @@
+from .. import create_ctx
+
+
+def _dial(value, increment_btn, lock_btn=None):
+    """Button/swipe presses to dial a wheel from its default (1) up to
+    `value`, then lock it in."""
+    from krux.input import BUTTON_ENTER
+
+    return [increment_btn] * (value - 1) + [lock_btn or BUTTON_ENTER]
+
+
+def test_new_12w_from_entropy_app_2xd8(m5stickv, mocker):
+    """
+    Draws 11 whole words via the 2XD8 booklet method's two-wheel picker
+    (White, Black die faces 1..8 cycling), revealing the card and then the
+    word after each roll pair, then confirms the computed checksum word
+    makes a valid 12-word mnemonic.
+    """
+    from krux.pages.new_mnemonic.entropy_app_2xd8 import EntropyApp2XD8
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE
+
+    # Die faces 1..8 cycling, 4 rolls (white/black x2) per word, 11 words = 44 rolls.
+    # Independently verified offline (bit-packing + embit.bip39.mnemonic_from_bytes)
+    # to draw "equal tattoo equal tattoo equal tattoo equal tattoo equal tattoo equal"
+    # with "able" computed as the valid checksum word -- same math as the original
+    # keypad-driven implementation, only the input method (wheel dial vs keypad tap)
+    # changed, so the expected mnemonic is unchanged.
+    ROLLS = [(i % 8) + 1 for i in range(44)]
+    MNEMONIC = "equal tattoo equal tattoo equal tattoo equal tattoo equal tattoo equal able"
+
+    BTN_SEQUENCE = [BUTTON_ENTER, BUTTON_ENTER]  # choose 12 words, then "Proceed?"
+    roll_iter = iter(ROLLS)
+    for _word in range(11):
+        for _roll in range(4):  # white1, black1, white2, black2
+            BTN_SEQUENCE += _dial(next(roll_iter), BUTTON_PAGE)
+        BTN_SEQUENCE += [BUTTON_ENTER]  # dismiss the word-reveal screen
+    BTN_SEQUENCE += [BUTTON_ENTER]  # dismiss the "Words Drawn" list
+    BTN_SEQUENCE += [BUTTON_ENTER]  # confirm "Compute checksum word...?"
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    entropy_app_2xd8 = EntropyApp2XD8(ctx)
+    entropy = entropy_app_2xd8.new_key()
+
+    assert entropy is not None
+    assert len(entropy) == 16  # 128 bits for a 12-word mnemonic
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    from embit.bip39 import mnemonic_from_bytes
+
+    words = mnemonic_from_bytes(entropy)
+    assert words == MNEMONIC
+    # The first 11 words are exactly what was drawn from the dice (not hashed).
+    assert words.split()[:11] == MNEMONIC.split()[:11]
+
+
+def test_new_12w_from_entropy_app_2xd8_via_swipe(m5stickv, mocker):
+    """
+    Same draw as test_new_12w_from_entropy_app_2xd8, but every wheel is dialed with
+    SWIPE_DOWN (the code touchscreen devices like the Amigo produce on a
+    real downward swipe) and locked with BUTTON_TOUCH (a tap), instead of
+    the physical BUTTON_PAGE/BUTTON_ENTER a button-only device would send.
+    The widget's own logic never branches on device type -- it only checks
+    button-code membership in INCREMENT/DECREMENT/LOCK_IN -- so this proves
+    the touchscreen input path end-to-end without needing the desktop
+    simulator's sequence scripting, which has no drag/swipe support at all.
+    """
+    from krux.pages.new_mnemonic.entropy_app_2xd8 import EntropyApp2XD8
+    from krux.input import BUTTON_ENTER, BUTTON_TOUCH, SWIPE_DOWN
+
+    ROLLS = [(i % 8) + 1 for i in range(44)]
+    MNEMONIC = "equal tattoo equal tattoo equal tattoo equal tattoo equal tattoo equal able"
+
+    BTN_SEQUENCE = [BUTTON_ENTER, BUTTON_ENTER]  # choose 12 words, then "Proceed?"
+    roll_iter = iter(ROLLS)
+    for _word in range(11):
+        for _roll in range(4):
+            BTN_SEQUENCE += _dial(next(roll_iter), SWIPE_DOWN, BUTTON_TOUCH)
+        BTN_SEQUENCE += [BUTTON_TOUCH]  # dismiss the word-reveal screen (a tap)
+    BTN_SEQUENCE += [BUTTON_TOUCH]  # dismiss the "Words Drawn" list
+    BTN_SEQUENCE += [BUTTON_ENTER]  # confirm "Compute checksum word...?"
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    entropy_app_2xd8 = EntropyApp2XD8(ctx)
+    entropy = entropy_app_2xd8.new_key()
+
+    assert entropy is not None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+    from embit.bip39 import mnemonic_from_bytes
+
+    assert mnemonic_from_bytes(entropy) == MNEMONIC
+
+
+def test_new_12w_from_entropy_app_2xd8_not_proceed(m5stickv, mocker):
+    """User declines the initial 'Proceed?' prompt -- no entropy is captured"""
+    from krux.pages.new_mnemonic.entropy_app_2xd8 import EntropyApp2XD8
+    from krux.input import BUTTON_ENTER, BUTTON_PAGE_PREV
+
+    BTN_SEQUENCE = [BUTTON_ENTER] + [BUTTON_PAGE_PREV]  # 12 words, then decline
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    entropy_app_2xd8 = EntropyApp2XD8(ctx)
+    entropy = entropy_app_2xd8.new_key()
+
+    assert entropy is None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
+
+
+def test_cancel_new_12w_from_entropy_app_2xd8(m5stickv, mocker):
+    """A swipe-left (long-press on button-only devices) mid-roll prompts to
+    cancel; confirming exits the whole draw"""
+    from krux.pages.new_mnemonic.entropy_app_2xd8 import EntropyApp2XD8
+    from krux.input import BUTTON_ENTER, SWIPE_LEFT
+
+    BTN_SEQUENCE = [
+        BUTTON_ENTER,  # 12 words
+        BUTTON_ENTER,  # Proceed
+        SWIPE_LEFT,  # cancel mid-roll (before any dial presses)
+        BUTTON_ENTER,  # confirm "Are you sure?" -> Yes
+    ]
+
+    ctx = create_ctx(mocker, BTN_SEQUENCE)
+    entropy_app_2xd8 = EntropyApp2XD8(ctx)
+    entropy = entropy_app_2xd8.new_key()
+
+    assert entropy is None
+    assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)


### PR DESCRIPTION
## Summary
Adds **New Mnemonic → Via Entropy App 2XD8**.

Two distinguishable D8 dice (White / Black) draw whole BIP39 words, matching the printed [2XD8 Entropy Booklet](https://github.com/bowtiedcrake/2xd8-entropy-booklet). This is not the existing D6/D20 path, which SHA-256 hashes a roll string. The last word is the BIP39 checksum, computed on the device.

## Files
- `src/krux/pages/new_mnemonic/entropy_app_2xd8.py`
- `src/krux/pages/login.py` (one menu item + handler)
- `tests/pages/new_mnemonic/test_entropy_app_2xd8.py`
- `simulator/sequences/entropy-app-2xd8-demo.txt`
- `simulator/sequences/entropy-app-2xd8-demo-amigo.txt`

## Test plan
- [ ] `pytest tests/pages/new_mnemonic/test_entropy_app_2xd8.py`
- [ ] Simulator: New Mnemonic → Via Entropy App 2XD8 (M5StickV and Amigo sequences)

Branched from `develop` per CONTRIBUTING.