### PR TITLE
 docs: update mkdocs.yml 

### DIFF
--- a/docs/getting-started/installing/from-gui/verify-download.en.md
+++ b/docs/getting-started/installing/from-gui/verify-download.en.md
@@ -55,7 +55,7 @@ $file = Split-Path $exe -Leaf
 (Select-String $file '.\{{latest_installer_sha}}').Line.Split()[0].ToUpper()
 ```
 
-> 🛡️  TIP: If you followed the authenticity/integrity checks steps presented, you already
+> 🛡️  TIP: If you followed the authenticity **AND** integrity checks steps presented, you already
 have the assurance that the software is from a verified and genuine software publisher.
 This will also help establish a chain of trust when you perform the firmware verification
 step before flashing.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,15 +49,14 @@ docs_dir: docs
 site_dir: public
 extra:
   latest_krux: krux-v26.08.0
-  latest_installer: v0.0.21
-  latest_installer_rpm: krux_installer-0.0.21-1.x86_64.rpm
-  latest_installer_deb: krux_installer_0.0.21_amd64.deb
-  latest_installer_win: krux_installer_v0.0.21_Setup.exe
-  latest_installer_mac_arm: krux_installer_0.0.21_arm64.dmg
-  latest_installer_mac_intel: krux-installer_0.0.20_x86_64.dmg
-  latest_installer_sha: krux-installer.SHA256.txt
-  latest_installer_sig: krux-installer.SHA256.txt.sig
-  latest_installer_key: B4281DDDFBBD207BFA4113138974C90299326322
+  latest_installer: v0.0.23
+  latest_installer_rpm: krux-installer-0.0.23-1.x86_64.rpm
+  latest_installer_deb: krux-installer_0.0.23_amd64.deb
+  latest_installer_win: krux-installer_v0.0.23_Setup.exe
+  latest_installer_mac_arm: krux-installer_0.0.23_arm64.dmg
+  latest_installer_sha: krux-installer_0.0.23.SHA256.txt
+  latest_installer_sig: krux-installer_0.0.23.SHA256.txt.asc
+  latest_installer_key: C43B4A5325273ABA93A8EED5B38829728980AA8B
   latest_installer_keyserver: hkps://keys.openpgp.org
   social:
     - icon: fontawesome/solid/bullhorn


### PR DESCRIPTION
### What is this PR for?

This PR:

- updates `qlrd` contributor key as well update `yaml` variables that points to correct binaries as well correct authenticity and integrity check files.
- replaces a simple `/` to `**AND**` in the diff to emphasize the importance of verify both by the authenticity of the integrity check file as well the integrity check of binaries itself. With only `/` someone could not understand the needed meaning to follow a correct check procedure.

Refs #931.

### Changes made to:
- [ ] Code
- [ ] Tests
- [x] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Other

## Notes to reviewers

Steps to reproduce:

- `uv sync --frozen --extra docs`
- `uv run poe docs`
- navigate to `installing from gui` > `verify` sections
- try to download binaries and check files from links
- copy/paste provided commands to check guide's correctness 