### PR TITLE
test: cover display.py, test display init embed_fire and extra_bottom_lines

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -43,7 +43,6 @@ def test_init(mocker, multiple_devices):
     mocker.spy(Display, "set_pmu_backlight")
 
     if board.config["type"] == "m5stickv":
-
         # Test the pmu backlight brightness levels
         # for m5stickv, 1 to 5 are valid brightness levels
         # (1 inclusive and 6 exclusive)
@@ -88,6 +87,20 @@ def test_init(mocker, multiple_devices):
         assert isinstance(d, Display)
         d.initialize_lcd.assert_called()
         krux.display.lcd.init.assert_called_once()
+
+
+def test_init_embed_fire(mocker, embed_fire):
+    mocker.patch("krux.display.lcd", new=mocker.MagicMock())
+    import krux
+    from krux.display import Display
+
+    d = Display()
+    d.initialize_lcd()
+
+    krux.display.lcd.init.assert_called_once()
+    assert krux.display.lcd.init.call_args.kwargs["type"] == 6
+    assert krux.display.lcd.init.call_args.kwargs["lcd_type"] == 6
+    assert krux.display.lcd.init.call_args.kwargs["invert"] is False
 
 
 def test_width(mocker, m5stickv):
@@ -1063,13 +1076,44 @@ def test_render_image_with_double_subtitle(mocker, multiple_devices):
         krux.display.lcd.display.assert_called_once_with(
             img, oft=(40, 40), roi=(0, 0, 320, 240)
         )
-    elif board.config["type"] == "dock":
-        krux.display.lcd.display.assert_called_once_with(
-            img, oft=(26, 0), roi=(34, 0, 262, 240)
-        )
     elif board.config["type"] == "cube":
         krux.display.lcd.display.assert_called_once_with(
             img, oft=(24, 0), roi=(72, 0, 186, 240)
+        )
+    else:
+        # Do not silently forget other devices, while some
+        # share sibling devices on default-value regions
+        # for different devices
+        krux.display.lcd.display.assert_called_once_with(
+            img, oft=(26, 0), roi=(34, 0, 262, 240)
+        )
+
+
+def test_render_image_with_extra_bottom_line(mocker, multiple_devices):
+    mocker.patch("krux.display.lcd", new=mocker.MagicMock())
+    import krux
+    from krux.display import Display
+    import board
+
+    d = Display()
+    img = mocker.MagicMock()
+
+    # one extra line reserved for same config above
+    d.render_image(img, title_lines=1, double_subtitle=True, extra_bottom_lines=1)
+    if board.config["type"] == "m5stickv":
+        assert krux.display.lcd.display.call_args.kwargs["oft"] == (24, 0)
+        assert krux.display.lcd.display.call_args.kwargs["roi"] == (92, 52, 161, 135)
+    elif board.config["type"] == "amigo":
+        krux.display.lcd.display.assert_called_once_with(
+            img, oft=(40, 40), roi=(0, 0, 320, 240)
+        )
+    elif board.config["type"] == "cube":
+        krux.display.lcd.display.assert_called_once_with(
+            img, oft=(24, 0), roi=(72, 0, 172, 240)
+        )
+    else:
+        krux.display.lcd.display.assert_called_once_with(
+            img, oft=(26, 0), roi=(34, 0, 246, 240)
         )
 
 


### PR DESCRIPTION
### What is this PR for?

This commit add a `test_init_embed_fire` and a `test_render_image_with_extra_bottom_line` for region cut in `render_image`.

Instead of adding boards to the `multiple_devices` fixture, which would grow every parametrized test time, i propose that the `"dock"` branch of the render tests would come a shared config on some display tests, so it could be an `else` branch for other devices (yahboom, wonder_mv, wonder_k share some default values, like region and font size, so they assert same values). They are being silently skipped while being called anyways, so this `else` branch is just another test without significant time increase.

### Changes made to:
- [ ] Code
- [x] Tests
- [ ] Docs
- [ ] CHANGELOG


### Did you build the code and tested on device?
- [ ] Yes, build and tested on <!-- device-name -->

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: increase coverage, do not skip some devices on tests on `tests/display.py` while keep a reasonable test time.

### Note to reviewers

- added new test is unit-only. Maybe deserves further investigation

For means to contextualize the test time, i ran 3 rounds of `uv run poe test-cov` (in seconds):

 - `origin/develop`:   (`66.14`, `65.42`, `65.78`)
 - `7894669b (#948)`:  (`66.68`, `65.23`, `64.81`)
 - `42ea328 (this)`:   (`67.13`, `64.81`, `65.21`)